### PR TITLE
Bug: Puppet creates empty key files when using Hiera and create_resources()

### DIFF
--- a/manifests/gpgkey.pp
+++ b/manifests/gpgkey.pp
@@ -47,7 +47,7 @@ define yum::gpgkey (
 
   if ($content == '') and ($source == '') {
     fail('Missing params: $content or $source must be specified')
-  } elsif $content {
+  } elsif $content != '' {
     File[$path] {
       content => $content
     }


### PR DESCRIPTION
How to reproduce:
**hiera .yaml**
```
yum::gpgkey:
  '/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6.puppet-managed':
    path: '/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6.puppet-managed'
    ensure: 'present'
    source: puppet:///modules/yum/gpgkey/RPM-GPG-KEY-EPEL-6
```
manifest.pp:
```
$yum_gpgkeys = hiera_hash("yum::gpgkey")
create_resources("yum::gpgkey", $yum_gpgkeys)
```