### PR TITLE
Remove dependency breaking puppet module install

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -59,10 +59,6 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": "3.3.x"
-    },
-    {
       "name": "puppet",
       "version_requirement": ">= 3.0.0 < 5.0.0"
     }


### PR DESCRIPTION
Ensure that puppet module install doesn't fail with:

    Error: Could not install module 'puppet-yum' (???)
      No version of 'puppet-yum' can satisfy all dependencies
        Use `puppet module install --ignore-dependencies` to install only this module