### PR TITLE
Replace validate functions with validate_legacy.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -26,10 +26,10 @@ define yum::config (
   $key     = $title,
   $section = 'main'
 ) {
-  validate_string($key, $section)
+  validate_legacy(String, 'validate_string', $key, $section)
 
   unless is_integer($ensure) {
-    validate_string($ensure)
+    validate_legacy(String, 'validate_string', $ensure)
   }
 
   $_changes = $ensure ? {

--- a/manifests/gpgkey.pp
+++ b/manifests/gpgkey.pp
@@ -35,8 +35,8 @@ define yum::gpgkey (
   $group   = 'root',
   $mode    = '0644'
 ) {
-  validate_absolute_path($path)
-  validate_string($owner, $group, $mode)
+  validate_legacy(Stdlib::Absolutepath, 'validate_absolute_path', $path)
+  validate_legacy(String, 'validate_string', $owner, $group, $mode)
 
   file { $path:
     ensure => $ensure,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,15 +31,15 @@ class yum (
   $keep_kernel_devel = $yum::params::keep_kernel_devel
 ) inherits yum::params {
 
-  validate_bool($keepcache, $exactarch, $obsoletes, $gpgcheck)
-  validate_bool($keep_kernel_devel)
+  validate_legacy(Boolean, 'validate_bool', $keepcache, $exactarch, $obsoletes)
+  validate_legacy(Boolean, 'validate_bool', $gpgcheck, $keep_kernel_devel)
 
   unless is_integer($installonly_limit) {
-    validate_string($installonly_limit)
+    validate_legacy(String, 'validate_string', $installonly_limit)
   }
 
   unless is_integer($debuglevel) {
-    validate_string($debuglevel)
+    validate_legacy(String, 'validate_string', $debuglevel)
   }
 
   # configure Yum

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -25,7 +25,7 @@ define yum::install (
   $ensure  = present,
   $timeout = undef,
 ) {
-  validate_string($source)
+  validate_legacy(String, 'validate_string', $source)
 
   Exec {
     path        => '/bin:/usr/bin:/sbin:/usr/sbin',


### PR DESCRIPTION
When referenced, stdlib warned that the validate functions are
deprecated and that validate_legacy should be used for backwards-
compatibility.