### PR TITLE
Add parameter clean_old_kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ class { 'yum':
   gpgcheck          => false|true,
   installonly_limit => number,
   keep_kernel_devel => false|true,
+  clean_old_kernels => false|true,
 }
 ```
 
-If `installonly_limit` is changed, purging of old kernel packages is triggered.
+If `installonly_limit` is changed, purging of old kernel packages is triggered if `clean_old_kernels` is `true`.
 
 ### yum::config
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,11 +28,12 @@ class yum (
   $obsoletes         = $yum::params::obsoletes,
   $gpgcheck          = $yum::params::gpgcheck,
   $installonly_limit = $yum::params::installonly_limit,
-  $keep_kernel_devel = $yum::params::keep_kernel_devel
+  $keep_kernel_devel = $yum::params::keep_kernel_devel,
+  $clean_old_kernels = $yum::params::clean_old_kernels
 ) inherits yum::params {
 
   validate_bool($keepcache, $exactarch, $obsoletes, $gpgcheck)
-  validate_bool($keep_kernel_devel)
+  validate_bool($keep_kernel_devel, $clean_old_kernels)
 
   unless is_integer($installonly_limit) {
     validate_string($installonly_limit)
@@ -40,6 +41,12 @@ class yum (
 
   unless is_integer($debuglevel) {
     validate_string($debuglevel)
+  }
+
+  if $clean_old_kernels {
+    $_installonly_limit_notify = Exec['package-cleanup_oldkernels']
+  } else {
+    $_installonly_limit_notify = undef
   }
 
   # configure Yum
@@ -65,7 +72,7 @@ class yum (
 
   yum::config { 'installonly_limit':
     ensure => $installonly_limit,
-    notify => Exec['package-cleanup_oldkernels'],
+    notify => $_installonly_limit_notify,
   }
 
   # cleanup old kernels

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,7 @@ class yum::params {
       $gpgcheck = true
       $installonly_limit = 5
       $keep_kernel_devel = false
+      $clean_old_kernels = true
     }
     default: {
       fail("${::operatingsystem} not supported")

--- a/spec/classes/basic_spec.rb
+++ b/spec/classes/basic_spec.rb
@@ -12,6 +12,18 @@ describe 'yum' do
           it { is_expected.to compile.with_all_deps }
 
           it { is_expected.to contain_class('yum::params') }
+
+          it do
+            is_expected.to contain_yum__config('installonly_limit').with(
+              ensure: '5',
+              notify: 'Exec[package-cleanup_oldkernels]'
+            )
+          end
+        end
+
+        context 'clean_old_kernels => false' do
+          let(:params) { { clean_old_kernels: false } }
+          it { is_expected.to contain_yum__config('installonly_limit').without_notify }
         end
       end
     end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

Add parameter clean_old_kernels that can be used to disable cleaning up of old kernels when installonly_limit is changed