### PR TITLE
Comma separated values

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -22,9 +22,9 @@
 #   }
 #
 define yum::config (
-  Variant[Boolean, Integer, Enum['absent']] $ensure,
-  String                                    $key     = $title,
-  String                                    $section = 'main'
+  Variant[Boolean, Integer, Enum['absent'], String] $ensure,
+  String                                            $key     = $title,
+  String                                            $section = 'main'
 ) {
 
   $_ensure = $ensure ? {
@@ -34,7 +34,7 @@ define yum::config (
 
   $_changes = $ensure ? {
     'absent'  => "rm  ${key}",
-    default   => "set ${key} ${_ensure}",
+    default   => "set ${key} '${_ensure}'",
   }
 
   augeas { "yum.conf_${section}_${key}":

--- a/spec/defines/config_spec.rb
+++ b/spec/defines/config_spec.rb
@@ -13,7 +13,7 @@ describe 'yum::config' do
     it { is_expected.to compile.with_all_deps }
     it 'contains an Augeas resource with the correct changes' do
       is_expected.to contain_augeas("yum.conf_main_#{title}").with(
-        changes: 'set assumeyes 1'
+        changes: "set assumeyes '1'"
       )
     end
   end
@@ -25,7 +25,19 @@ describe 'yum::config' do
     it { is_expected.to compile.with_all_deps }
     it 'contains an Augeas resource with the correct changes' do
       is_expected.to contain_augeas("yum.conf_main_#{title}").with(
-        changes: 'set assumeyes 0'
+        changes: "set assumeyes '0'"
+      )
+    end
+  end
+
+  context 'ensure is a comma separated String' do
+    let(:title) { 'assumeyes' }
+    let(:params) { { ensure: '1, 2' } }
+
+    it { is_expected.to compile.with_all_deps }
+    it 'contains an Augeas resource with the correct changes' do
+      is_expected.to contain_augeas("yum.conf_main_#{title}").with(
+        changes: "set assumeyes '1, 2'"
       )
     end
   end


### PR DESCRIPTION
Wrapping `$ensure` in single quotes allows comma separated values.
voxpupuli/puppet-yum#21
