### PR TITLE
Comma seperated values puppet3

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -34,7 +34,7 @@ define yum::config (
 
   $_changes = $ensure ? {
     'absent'  => "rm  ${key}",
-    default   => "set ${key} ${ensure}",
+    default   => "set ${key} '${ensure}'",
   }
 
   augeas { "yum.conf_${section}_${key}":

--- a/spec/defines/basic_config_spec.rb
+++ b/spec/defines/basic_config_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'yum::config' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) do
+          facts
+        end
+        let(:pre_condition) { [ 'include ::yum', ] }
+
+        context 'ensure => "1, 2"' do
+          let(:title)  { 'exclude' }
+          let(:params) { { ensure: '1, 2' } }
+          it { is_expected.to contain_yum__config('exclude').with(
+            :ensure => '1, 2'
+          ) }
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
@bastelfreak 
Enable comma separated values in yum::config, basically same change as for puppet 4