### PR TITLE
Remove `section` parameter from `yum::config`

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -24,7 +24,6 @@
 define yum::config (
   Variant[Boolean, Integer, Enum['absent'], String] $ensure,
   String                                            $key     = $title,
-  String                                            $section = 'main'
 ) {
 
   $_ensure = $ensure ? {
@@ -37,10 +36,10 @@ define yum::config (
     default   => "set ${key} '${_ensure}'",
   }
 
-  augeas { "yum.conf_${section}_${key}":
+  augeas { "yum.conf_${key}":
     incl    => '/etc/yum.conf',
     lens    => 'Yum.lns',
-    context => "/files/etc/yum.conf/${section}/",
+    context => '/files/etc/yum.conf/main/',
     changes => $_changes,
   }
 }

--- a/spec/defines/config_spec.rb
+++ b/spec/defines/config_spec.rb
@@ -12,7 +12,7 @@ describe 'yum::config' do
 
     it { is_expected.to compile.with_all_deps }
     it 'contains an Augeas resource with the correct changes' do
-      is_expected.to contain_augeas("yum.conf_main_#{title}").with(
+      is_expected.to contain_augeas("yum.conf_#{title}").with(
         changes: "set assumeyes '1'"
       )
     end
@@ -24,7 +24,7 @@ describe 'yum::config' do
 
     it { is_expected.to compile.with_all_deps }
     it 'contains an Augeas resource with the correct changes' do
-      is_expected.to contain_augeas("yum.conf_main_#{title}").with(
+      is_expected.to contain_augeas("yum.conf_#{title}").with(
         changes: "set assumeyes '0'"
       )
     end
@@ -36,7 +36,7 @@ describe 'yum::config' do
 
     it { is_expected.to compile.with_all_deps }
     it 'contains an Augeas resource with the correct changes' do
-      is_expected.to contain_augeas("yum.conf_main_#{title}").with(
+      is_expected.to contain_augeas("yum.conf_#{title}").with(
         changes: "set assumeyes '1, 2'"
       )
     end


### PR DESCRIPTION
According to the man page for `yum.conf(5)`, `[main]` is the only valid
section for global Yum config options.  All other section names refer to
individual repositories.  This commit removes the `section` parameter in
the `yum::config` defined type, hard-coding it to `main`.

