### PR TITLE
Add module data for EPEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ yum::repos:
 
 ### Enable management of one of the pre-defined repos
 
-This module includes several pre-defined Yumrepos for easy management.  This example enables management of the Extras repository for CentOS using its default settings.
+This module includes several pre-defined Yumrepos for easy management.  This example enables management of the EPEL repository using its default settings.
 
 **NOTE:** This only works if the data for the repository is included with the module.  Please see the `/data` directory of this module for a list of available repos.
 
@@ -92,7 +92,7 @@ include 'yum'
 ```yaml
 ---
 yum::managed_repos:
-    - 'extras'
+    - 'epel'
 ```
 
 ### Enable management of one of the pre-defined repos AND modify its settings

--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -1,0 +1,54 @@
+---
+# This file contains miscellaneous, non-distro repositories.
+yum::repos:
+    # EPEL
+    epel:
+        name: "Extra Packages for Enterprise Linux %{facts.os.release.major} - $basearch"
+        mirrorlist: "https://mirrors.fedoraproject.org/metalink?repo=epel-%{facts.os.release.major}&arch=$basearch"
+        failovermethod: 'priority'
+        enabled: true
+        gpgcheck: true
+        gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-%{facts.os.release.major}"
+        target: '/etc/yum.repos.d/epel.repo'
+
+    epel-debuginfo:
+        name: "Extra Packages for Enterprise Linux %{facts.os.release.major} - $basearch - Debug"
+        mirrorlist: "https://mirrors.fedoraproject.org/metalink?repo=epel-debug-%{facts.os.release.major}&arch=$basearch"
+        failovermethod: 'priority'
+        enabled: false
+        gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-%{facts.os.release.major}"
+        gpgcheck: true
+        target: '/etc/yum.repos.d/epel.repo'
+
+    epel-source:
+        name: "Extra Packages for Enterprise Linux %{facts.os.release.major} - $basearch - Source"
+        mirrorlist: "https://mirrors.fedoraproject.org/metalink?repo=epel-source-%{facts.os.release.major}&arch=$basearch"
+        failovermethod: 'priority'
+        enabled: false
+        gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-%{facts.os.release.major}"
+        gpgcheck: true
+        target: '/etc/yum.repos.d/epel.repo'
+
+    epel-testing:
+        name: "Extra Packages for Enterprise Linux %{facts.os.release.major} - Testing - $basearch"
+        mirrorlist: "https://mirrors.fedoraproject.org/metalink?repo=testing-epel%{facts.os.release.major}&arch=$basearch"
+        failovermethod: 'priority'
+        enabled: false
+        gpgcheck: true
+        gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-%{facts.os.release.major}"
+
+    epel-testing-debuginfo:
+        name: "Extra Packages for Enterprise Linux %{facts.os.release.major} - Testing - $basearch - Debug"
+        mirrorlist: "https://mirrors.fedoraproject.org/metalink?repo=testing-debug-epel%{facts.os.release.major}&arch=$basearch"
+        failovermethod: 'priority'
+        enabled: false
+        gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-%{facts.os.release.major}"
+        gpgcheck: true
+
+    epel-testing-source:
+        name: "Extra Packages for Enterprise Linux %{facts.os.release.major} - Testing - $basearch - Source"
+        mirrorlist: "https://mirrors.fedoraproject.org/metalink?repo=testing-source-epel%{facts.os.release.major}&arch=$basearch"
+        failovermethod: 'priority'
+        enabled: false
+        gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-%{facts.os.release.major}"
+        gpgcheck: true

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -11,6 +11,10 @@ hierarchy:
         - "os/%{facts.os.family}/%{facts.os.name}"
         - "os/%{facts.os.family}"
 
+    - name: 'Non-OS Yumrepos'
+      backend: yaml
+      path: 'repos'
+
     - name: 'Common Data'
       backend: yaml
       path: 'common'


### PR DESCRIPTION
This adds the data required to enable EPEL via the `managed_yumrepos`
parameter.