### PR TITLE
Versionlock release string may contain dots

### DIFF
--- a/spec/defines/versionlock_spec.rb
+++ b/spec/defines/versionlock_spec.rb
@@ -49,6 +49,14 @@ describe 'yum::versionlock' do
     end
   end
 
+  context 'with a release containing dots' do
+    let(:title) { '1:java-1.7.0-openjdk-1.7.0.121-2.6.8.0.el7_3.x86_64' }
+
+    it 'contains a well-formed Concat::Fragment' do
+      is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("#{title}\n")
+    end
+  end
+
   context 'with an invalid title' do
     let(:title) { 'bash-4.1.2' }
 

--- a/types/versionlockstring.pp
+++ b/types/versionlockstring.pp
@@ -12,8 +12,8 @@
 #   # VERSION: Any valid version string. The only limitation here, according to the RPM manual, is that it may not contain a dash (`-`).
 #   type Yum::PackageVersion = Regexp[/[^-]+/]
 #
-#   # RELEASE: An unsigned integer
-#   type Yum::PackageRelease = Regexp[/[0-9\*]+/]
+#   # RELEASE: Any valid release string. Only limitation is that it is not a dash (`-`)
+#   type Yum::PackageRelease = Regexp[/[^-]+/]
 #
 #   # ARCH: Matches a string such as `el7.x86_64`.  This is actuall two sub-expressions.  See below.
 #   type Yum::PackageArch    = Regexp[/([0-9a-zZ-Z_\*]+)(?:\.(noarch|x86_64|i386|arm|ppc64|ppc64le|sparc64|ia64|alpha|ip|m68k|mips|mipsel|mk68k|mint|ppc|rs6000|s390|s390x|sh|sparc|xtensa|\*))?/]
@@ -40,4 +40,4 @@
 # @example An invalid string (wildcard spans the VERSION and RELEASE fields): `0:bash-4.*-el6.x86_64
 # @example An invlaid string (wildcard spans the VERSION, RELEASE, and ARCH fields): `0:bash-*`
 #
-type Yum::VersionlockString = Pattern[/^([0-9\*]+):([0-9a-zA-Z\._\+%\{\}\*-]+)-([^-]+)-([0-9\*]+)\.(([0-9a-zZ-Z_\*]+)(?:\.(noarch|x86_64|i386|arm|ppc64|ppc64le|sparc64|ia64|alpha|ip|m68k|mips|mipsel|mk68k|mint|ppc|rs6000|s390|s390x|sh|sparc|xtensa|\*))?)$/]
+type Yum::VersionlockString = Pattern[/^([0-9\*]+):([0-9a-zA-Z\._\+%\{\}\*-]+)-([^-]+)-([^-]+)\.(([0-9a-zZ-Z_\*]+)(?:\.(noarch|x86_64|i386|arm|ppc64|ppc64le|sparc64|ia64|alpha|ip|m68k|mips|mipsel|mk68k|mint|ppc|rs6000|s390|s390x|sh|sparc|xtensa|\*))?)$/]


### PR DESCRIPTION
Case example:

```
1:java-1.7.0-openjdk-1.7.0.121-2.6.8.0.el7_3.x86_64
```

Is a valid `E:N-V-R` for yum versionlock.
In this case the release is as defined in
Yum::VersionlockString is `2.6.8.0`  and so
dots must be permitted.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
