### PR TITLE
Fix EPEL repo IDs

### DIFF
--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -3,7 +3,7 @@
 yum::repos:
     # EPEL
     epel:
-        name: "Extra Packages for Enterprise Linux %{facts.os.release.major} - $basearch"
+        descr: "Extra Packages for Enterprise Linux %{facts.os.release.major} - $basearch"
         mirrorlist: "https://mirrors.fedoraproject.org/metalink?repo=epel-%{facts.os.release.major}&arch=$basearch"
         failovermethod: 'priority'
         enabled: true
@@ -12,7 +12,7 @@ yum::repos:
         target: '/etc/yum.repos.d/epel.repo'
 
     epel-debuginfo:
-        name: "Extra Packages for Enterprise Linux %{facts.os.release.major} - $basearch - Debug"
+        descr: "Extra Packages for Enterprise Linux %{facts.os.release.major} - $basearch - Debug"
         mirrorlist: "https://mirrors.fedoraproject.org/metalink?repo=epel-debug-%{facts.os.release.major}&arch=$basearch"
         failovermethod: 'priority'
         enabled: false
@@ -21,7 +21,7 @@ yum::repos:
         target: '/etc/yum.repos.d/epel.repo'
 
     epel-source:
-        name: "Extra Packages for Enterprise Linux %{facts.os.release.major} - $basearch - Source"
+        descr: "Extra Packages for Enterprise Linux %{facts.os.release.major} - $basearch - Source"
         mirrorlist: "https://mirrors.fedoraproject.org/metalink?repo=epel-source-%{facts.os.release.major}&arch=$basearch"
         failovermethod: 'priority'
         enabled: false
@@ -30,7 +30,7 @@ yum::repos:
         target: '/etc/yum.repos.d/epel.repo'
 
     epel-testing:
-        name: "Extra Packages for Enterprise Linux %{facts.os.release.major} - Testing - $basearch"
+        descr: "Extra Packages for Enterprise Linux %{facts.os.release.major} - Testing - $basearch"
         mirrorlist: "https://mirrors.fedoraproject.org/metalink?repo=testing-epel%{facts.os.release.major}&arch=$basearch"
         failovermethod: 'priority'
         enabled: false
@@ -38,7 +38,7 @@ yum::repos:
         gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-%{facts.os.release.major}"
 
     epel-testing-debuginfo:
-        name: "Extra Packages for Enterprise Linux %{facts.os.release.major} - Testing - $basearch - Debug"
+        descr: "Extra Packages for Enterprise Linux %{facts.os.release.major} - Testing - $basearch - Debug"
         mirrorlist: "https://mirrors.fedoraproject.org/metalink?repo=testing-debug-epel%{facts.os.release.major}&arch=$basearch"
         failovermethod: 'priority'
         enabled: false
@@ -46,7 +46,7 @@ yum::repos:
         gpgcheck: true
 
     epel-testing-source:
-        name: "Extra Packages for Enterprise Linux %{facts.os.release.major} - Testing - $basearch - Source"
+        descr: "Extra Packages for Enterprise Linux %{facts.os.release.major} - Testing - $basearch - Source"
         mirrorlist: "https://mirrors.fedoraproject.org/metalink?repo=testing-source-epel%{facts.os.release.major}&arch=$basearch"
         failovermethod: 'priority'
         enabled: false


### PR DESCRIPTION
Puppet's `yumrepo` type's `name` parameter maps to the `repositoryid`
attribute of concrete Yum repos, whereas the `yumrepo` type's `descr`
parameter maps to the concrete `name` attribute.  Prior to this commit
the two were confused in the EPEL repository data, causing parse errors.
This commit corrects this error, changing the `name` parameter keys to
`descr`.

Fixes #53