### PR TITLE
Add optional parameters to groupinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,12 +303,16 @@ yum::versionlock { '0:bash-4.1.2-9.el6_2.*':
 
 ### Install or remove *yum* package group
 
+Install yum [package groups](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/sec-working_with_package_groups).  To list groups: `yum group list`. Then use that name in your puppet manifest. With support for install_options (e.g. enable repos if disabled by default).
+
 ```puppet
 yum::group { 'X Window System':
-  ensure  => present,
-  timeout => 600,
+  ensure          => present,
+  timeout         => 600,
+  install_options => ['--enablerepo=*'];
 }
 ```
+
 
 ### Install or remove packages via `yum install`
 

--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -20,8 +20,8 @@
 #
 define yum::group (
   Enum['present', 'installed', 'absent', 'purged'] $ensure  = 'present',
-  Optional[Integer]                                $timeout = undef,
-  Optional[Array[String]]                          $install_options = [],
+  Integer                                          $timeout = undef,
+  Array[String]                                    $install_options = [],
 ) {
   Exec {
     path        => '/bin:/usr/bin:/sbin:/usr/sbin',

--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -19,10 +19,11 @@
 #   }
 #
 define yum::group (
-  Array[String]                                    $install_options = [],
-  Enum['present', 'installed', 'absent', 'purged'] $ensure  = 'present',
-  Optional[Integer]                                $timeout = undef,
+  Array[String[1]]                                    $install_options = [],
+  Enum['present', 'installed', 'absent', 'purged'] $ensure             = 'present',
+  Optional[Integer] $timeout                                           = undef,
 ) {
+
   Exec {
     path        => '/bin:/usr/bin:/sbin:/usr/sbin',
     environment => 'LC_ALL=C',

--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -6,6 +6,7 @@
 #   [*ensure*]   - specifies if package group should be
 #                  present (installed) or absent (purged)
 #   [*timeout*]  - exec timeout for yum groupinstall command
+#   [*install_options*]  - options provided to yum groupinstall command
 #
 # Actions:
 #
@@ -20,6 +21,7 @@
 define yum::group (
   Enum['present', 'installed', 'absent', 'purged'] $ensure  = 'present',
   Optional[Integer]                                $timeout = undef,
+  Optional[Array[String]]                          $install_options = [],
 ) {
   Exec {
     path        => '/bin:/usr/bin:/sbin:/usr/sbin',
@@ -29,7 +31,7 @@ define yum::group (
   case $ensure {
     'present', 'installed', default: {
       exec { "yum-groupinstall-${name}":
-        command => "yum -y groupinstall '${name}'",
+        command => join(concat(["yum -y groupinstall '${name}'"], $install_options), ' '),
         unless  => "yum grouplist hidden '${name}' | egrep -i '^Installed.+Groups:$'",
         timeout => $timeout,
       }

--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -19,9 +19,9 @@
 #   }
 #
 define yum::group (
-  Enum['present', 'installed', 'absent', 'purged'] $ensure  = 'present',
-  Integer                                          $timeout = undef,
   Array[String]                                    $install_options = [],
+  Enum['present', 'installed', 'absent', 'purged'] $ensure  = 'present',
+  Optional[Integer]                                $timeout = undef,
 ) {
   Exec {
     path        => '/bin:/usr/bin:/sbin:/usr/sbin',

--- a/spec/defines/group_spec.rb
+++ b/spec/defines/group_spec.rb
@@ -23,4 +23,11 @@ describe 'yum::group' do
     it { is_expected.to compile.with_all_deps }
     it { is_expected.to contain_exec("yum-groupinstall-#{title}").with_timeout(30) }
   end
+  context 'with an install option specified' do
+    let(:title) { 'Core' }
+    let(:params) { { install_options: ['--enablerepo=epel'] } }
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_exec("yum-groupinstall-#{title}").with_command("yum -y groupinstall 'Core' --enablerepo=epel") }
+  end
 end


### PR DESCRIPTION
We want to install a group using an extra repository not enabled by
default.
We can now enable that extra repository during group install using the
`install_options` parameter.

E.g.:

  yum::group {
    'mate-desktop-environment':
      ensure          => present,
      install_options => ['--enablerepo=epel']
  }

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
