### PR TITLE
migrate Hiera 4 to Hiera 5

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,20 +1,21 @@
 ---
-version: 4
-datadir: data
+version: 5
+
+defaults:
+  datadir: data
+  data_hash: yaml_data
+
 hierarchy:
     - name: 'OS Data'
-      backend: yaml
       paths:
-        - "os/%{facts.os.family}/%{facts.os.name}/%{facts.os.release.full}"
-        - "os/%{facts.os.family}/%{facts.os.name}/%{facts.os.release.major}/%{facts.os.release.minor}"
-        - "os/%{facts.os.family}/%{facts.os.name}/%{facts.os.release.major}"
-        - "os/%{facts.os.family}/%{facts.os.name}"
-        - "os/%{facts.os.family}"
+        - 'os/%{facts.os.family}/%{facts.os.name}/%{facts.os.release.full}.yaml'
+        - 'os/%{facts.os.family}/%{facts.os.name}/%{facts.os.release.major}/%{facts.os.release.minor}.yaml'
+        - 'os/%{facts.os.family}/%{facts.os.name}/%{facts.os.release.major}.yaml'
+        - 'os/%{facts.os.family}/%{facts.os.name}.yaml'
+        - 'os/%{facts.os.family}.yaml'
 
     - name: 'Non-OS Yumrepos'
-      backend: yaml
-      path: 'repos'
+      path: 'repos.yaml'
 
     - name: 'Common Data'
-      backend: yaml
-      path: 'common'
+      path: 'common.yaml'

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,6 @@
   "source": "https://github.com/voxpupuli/puppet-yum.git",
   "project_page": "https://github.com/voxpupuli/puppet-yum",
   "issues_url": "https://github.com/voxpupuli/puppet-yum/issues",
-  "data_provider": "hiera",
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
This PR fixes #77 .

Currently our required Puppet version according to metadata.json is at least 4.10.9 which means that Hiera 5 is always available.
