### PR TITLE
Fixes #95 Add EPEL GPG Key and logic to handle yum::gpgkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,35 @@ yum::repos:
         target: '/etc/yum.repos.d/example.repo'
 ```
 
+You can include gpgkeys in yaml as well, and if the key filename matches a
+gpgkey from a mananged repo, it will be included. For example a gpg key for the
+repo above could look like:
+
+```yaml
+---
+yum::gpgkeys:
+    /etc/pki/gpm-gpg/RPM-GPG-KEY-Example:
+        content: |
+            -----BEGIN PGP PUBLIC KEY BLOCK-----
+            Version: GnuPG v1.4.11 (GNU/Linux)
+
+            mQINBFKuaIQBEAC1UphXwMqCAarPUH/ZsOFslabeTVO2pDk5YnO96f+rgZB7xArB
+            OSeQk7B90iqSJ85/c72OAn4OXYvT63gfCeXpJs5M7emXkPsNQWWSju99lW+AqSNm
+            (SNIP SEVERAL LINES)
+            RjsC7FDbL017qxS+ZVA/HGkyfiu4cpgV8VUnbql5eAZ+1Ll6Dw==
+            =hdPa
+            -----END PGP PUBLIC KEY BLOCK-----
+```
+
+... or
+
+```yaml
+---
+yum::gpgkeys:
+    /etc/pki/gpm-gpg/RPM-GPG-KEY-Example:
+        source: puppet:///repos/RPM-GPG-KEY-Example
+```
+
 ### Enable management of one of the pre-defined repos
 
 This module includes several pre-defined Yumrepos for easy management.  This example enables management of the EPEL repository using its default settings.

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -7,6 +7,11 @@ lookup_options:
             strategy: 'deep'
             knockout_prefix: '--'
             merge_hash_arrays: true
+    yum::gpgkeys:
+        merge:
+            strategy: 'deep'
+            knockout_prefix: '--'
+            merge_hash_arrays: true
     yum::managed_repos:
         merge: 'unique'
     yum::os_default_repos:

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,0 +1,67 @@
+---
+## osfamily: RedHat
+
+yum::gpgkeys:
+  /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6: # https://archive.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6
+    content: |
+      -----BEGIN PGP PUBLIC KEY BLOCK-----
+      Version: GnuPG v1.4.5 (GNU/Linux)
+
+      mQINBEvSKUIBEADLGnUj24ZVKW7liFN/JA5CgtzlNnKs7sBg7fVbNWryiE3URbn1
+      JXvrdwHtkKyY96/ifZ1Ld3lE2gOF61bGZ2CWwJNee76Sp9Z+isP8RQXbG5jwj/4B
+      M9HK7phktqFVJ8VbY2jfTjcfxRvGM8YBwXF8hx0CDZURAjvf1xRSQJ7iAo58qcHn
+      XtxOAvQmAbR9z6Q/h/D+Y/PhoIJp1OV4VNHCbCs9M7HUVBpgC53PDcTUQuwcgeY6
+      pQgo9eT1eLNSZVrJ5Bctivl1UcD6P6CIGkkeT2gNhqindRPngUXGXW7Qzoefe+fV
+      QqJSm7Tq2q9oqVZ46J964waCRItRySpuW5dxZO34WM6wsw2BP2MlACbH4l3luqtp
+      Xo3Bvfnk+HAFH3HcMuwdaulxv7zYKXCfNoSfgrpEfo2Ex4Im/I3WdtwME/Gbnwdq
+      3VJzgAxLVFhczDHwNkjmIdPAlNJ9/ixRjip4dgZtW8VcBCrNoL+LhDrIfjvnLdRu
+      vBHy9P3sCF7FZycaHlMWP6RiLtHnEMGcbZ8QpQHi2dReU1wyr9QgguGU+jqSXYar
+      1yEcsdRGasppNIZ8+Qawbm/a4doT10TEtPArhSoHlwbvqTDYjtfV92lC/2iwgO6g
+      YgG9XrO4V8dV39Ffm7oLFfvTbg5mv4Q/E6AWo/gkjmtxkculbyAvjFtYAQARAQAB
+      tCFFUEVMICg2KSA8ZXBlbEBmZWRvcmFwcm9qZWN0Lm9yZz6JAjYEEwECACAFAkvS
+      KUICGw8GCwkIBwMCBBUCCAMEFgIDAQIeAQIXgAAKCRA7Sd8qBgi4lR/GD/wLGPv9
+      qO39eyb9NlrwfKdUEo1tHxKdrhNz+XYrO4yVDTBZRPSuvL2yaoeSIhQOKhNPfEgT
+      9mdsbsgcfmoHxmGVcn+lbheWsSvcgrXuz0gLt8TGGKGGROAoLXpuUsb1HNtKEOwP
+      Q4z1uQ2nOz5hLRyDOV0I2LwYV8BjGIjBKUMFEUxFTsL7XOZkrAg/WbTH2PW3hrfS
+      WtcRA7EYonI3B80d39ffws7SmyKbS5PmZjqOPuTvV2F0tMhKIhncBwoojWZPExft
+      HpKhzKVh8fdDO/3P1y1Fk3Cin8UbCO9MWMFNR27fVzCANlEPljsHA+3Ez4F7uboF
+      p0OOEov4Yyi4BEbgqZnthTG4ub9nyiupIZ3ckPHr3nVcDUGcL6lQD/nkmNVIeLYP
+      x1uHPOSlWfuojAYgzRH6LL7Idg4FHHBA0to7FW8dQXFIOyNiJFAOT2j8P5+tVdq8
+      wB0PDSH8yRpn4HdJ9RYquau4OkjluxOWf0uRaS//SUcCZh+1/KBEOmcvBHYRZA5J
+      l/nakCgxGb2paQOzqqpOcHKvlyLuzO5uybMXaipLExTGJXBlXrbbASfXa/yGYSAG
+      iVrGz9CE6676dMlm8F+s3XXE13QZrXmjloc6jwOljnfAkjTGXjiB7OULESed96MR
+      XtfLk0W5Ab9pd7tKDR6QHI7rgHXfCopRnZ2VVQ==
+      =V/6I
+      -----END PGP PUBLIC KEY BLOCK-----
+
+  /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7: # https://archive.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+    content: |
+      -----BEGIN PGP PUBLIC KEY BLOCK-----
+      Version: GnuPG v1.4.11 (GNU/Linux)
+
+      mQINBFKuaIQBEAC1UphXwMqCAarPUH/ZsOFslabeTVO2pDk5YnO96f+rgZB7xArB
+      OSeQk7B90iqSJ85/c72OAn4OXYvT63gfCeXpJs5M7emXkPsNQWWSju99lW+AqSNm
+      jYWhmRlLRGl0OO7gIwj776dIXvcMNFlzSPj00N2xAqjMbjlnV2n2abAE5gq6VpqP
+      vFXVyfrVa/ualogDVmf6h2t4Rdpifq8qTHsHFU3xpCz+T6/dGWKGQ42ZQfTaLnDM
+      jToAsmY0AyevkIbX6iZVtzGvanYpPcWW4X0RDPcpqfFNZk643xI4lsZ+Y2Er9Yu5
+      S/8x0ly+tmmIokaE0wwbdUu740YTZjCesroYWiRg5zuQ2xfKxJoV5E+Eh+tYwGDJ
+      n6HfWhRgnudRRwvuJ45ztYVtKulKw8QQpd2STWrcQQDJaRWmnMooX/PATTjCBExB
+      9dkz38Druvk7IkHMtsIqlkAOQMdsX1d3Tov6BE2XDjIG0zFxLduJGbVwc/6rIc95
+      T055j36Ez0HrjxdpTGOOHxRqMK5m9flFbaxxtDnS7w77WqzW7HjFrD0VeTx2vnjj
+      GqchHEQpfDpFOzb8LTFhgYidyRNUflQY35WLOzLNV+pV3eQ3Jg11UFwelSNLqfQf
+      uFRGc+zcwkNjHh5yPvm9odR1BIfqJ6sKGPGbtPNXo7ERMRypWyRz0zi0twARAQAB
+      tChGZWRvcmEgRVBFTCAoNykgPGVwZWxAZmVkb3JhcHJvamVjdC5vcmc+iQI4BBMB
+      AgAiBQJSrmiEAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAKCRBqL66iNSxk
+      5cfGD/4spqpsTjtDM7qpytKLHKruZtvuWiqt5RfvT9ww9GUUFMZ4ZZGX4nUXg49q
+      ixDLayWR8ddG/s5kyOi3C0uX/6inzaYyRg+Bh70brqKUK14F1BrrPi29eaKfG+Gu
+      MFtXdBG2a7OtPmw3yuKmq9Epv6B0mP6E5KSdvSRSqJWtGcA6wRS/wDzXJENHp5re
+      9Ism3CYydpy0GLRA5wo4fPB5uLdUhLEUDvh2KK//fMjja3o0L+SNz8N0aDZyn5Ax
+      CU9RB3EHcTecFgoy5umRj99BZrebR1NO+4gBrivIfdvD4fJNfNBHXwhSH9ACGCNv
+      HnXVjHQF9iHWApKkRIeh8Fr2n5dtfJEF7SEX8GbX7FbsWo29kXMrVgNqHNyDnfAB
+      VoPubgQdtJZJkVZAkaHrMu8AytwT62Q4eNqmJI1aWbZQNI5jWYqc6RKuCK6/F99q
+      thFT9gJO17+yRuL6Uv2/vgzVR1RGdwVLKwlUjGPAjYflpCQwWMAASxiv9uPyYPHc
+      ErSrbRG0wjIfAR3vus1OSOx3xZHZpXFfmQTsDP7zVROLzV98R3JwFAxJ4/xqeON4
+      vCPFU6OsT3lWQ8w7il5ohY95wmujfr6lk89kEzJdOTzcn7DBbUru33CQMGKZ3Evt
+      RjsC7FDbL017qxS+ZVA/HGkyfiu4cpgV8VUnbql5eAZ+1Ll6Dw==
+      =hdPa
+      -----END PGP PUBLIC KEY BLOCK-----

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,11 @@
 #   Values in this array will be subtracted from the `managed_repos` array as a last step before
 #   instantiation.
 #
+# @param gpgkeys
+#   A hash of yum::gpgkey types, which will be automatically included if they
+#   are referenced by a managed_repo. This will use the same merging behavior
+#   as repos.
+#
 # @example Enable management of the default repos for a supported OS:
 #   ```yaml
 #   ---
@@ -104,6 +109,7 @@ class yum (
   Boolean $manage_os_default_repos = false,
   Array[String] $os_default_repos = [],
   Array[String] $repo_exclusions = [],
+  Hash[String, Hash[String, String]] $gpgkeys = {},
 ) {
 
   $module_metadata            = load_module_metadata($module_name)
@@ -130,6 +136,20 @@ class yum (
         Resource['yumrepo'] {
           $yumrepo: * => $attributes,
         }
+        # Handle GPG Key
+        if has_key($attributes, 'gpgkey') {
+          $matches = $attributes['gpgkey'].match('^file://(.*)$')
+          if $matches {
+            $gpgkey = $matches[1]
+            if $gpgkey =~ Stdlib::AbsolutePath and has_key($gpgkeys, $gpgkey) {
+              if !defined(Yum::Gpgkey[$gpgkey]) {
+                yum::gpgkey { $gpgkey:
+                  * => $gpgkeys[$gpgkey],
+                }
+              } # end if Yum::Gpgkey[$gpgkey] is not defined
+            } # end if $gpgkey exists in gpgkeys
+          } # end if gpgkey is a file:// resource
+        } # end if $attributes has a gpgkey
       }
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.10.0 < 5.0.0"
+      "version_requirement": ">= 4.13.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/concat",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -267,6 +267,18 @@ describe 'yum' do
 
         it { is_expected.to contain_exec('package-cleanup_oldkernels').without_subscribe }
       end
+
+      context 'when epel is enabled' do
+        let(:params) { { managed_repos: ['epel'] } }
+
+        it { is_expected.to contain_yumrepo('epel') }
+        case facts[:os]['release']['major']
+        when '7'
+          it { is_expected.to contain_yum__gpgkey('/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7') }
+        when '6'
+          it { is_expected.to contain_yum__gpgkey('/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6') }
+        end
+      end
     end
   end
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Add the EPEL GPG key for EL6 and EL7, and adding the logic to automatically include GPG Keys from the yum::gpgkeys hash, including tests and some basic docs.

#### This Pull Request (PR) fixes the following issues
Fixes #95 
