### PR TITLE
Clean yum metadata after versionlock file update

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,12 +254,22 @@ yum::versionlock { '0:bash-4.1.2-9.el6_2.*':
   ensure => present,
 }
 ```
-
 Use the following command to retrieve a properly-formated string:
 
 ```sh
 PACKAGE_NAME='bash'
 rpm -q "$PACKAGE_NAME" --qf '%|EPOCH?{%{EPOCH}}:{0}|:%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n'
+```
+
+To run a `yum clean all` after the versionlock file is updated.
+
+```puppet
+class{'yum::plugin::versionlock':
+  clean => true,
+}
+yum::versionlock { '0:bash-4.1.2-9.el6_2.*':
+  ensure => present,
+}
 ```
 
 ### Install or remove *yum* package group

--- a/manifests/clean.pp
+++ b/manifests/clean.pp
@@ -1,0 +1,9 @@
+# A $(yum clean all) Exec to be notified if desired.
+class yum::clean {
+
+  exec{'yum_clean_all':
+    command     => '/usr/bin/yum clean all',
+    refreshonly => true,
+  }
+
+}

--- a/manifests/plugin/versionlock.pp
+++ b/manifests/plugin/versionlock.pp
@@ -4,6 +4,7 @@
 #
 # Parameters:
 #   [*ensure*] - specifies if versionlock should be present or absent
+#   [*clean*] - specifies if yum clean all should be called after edits. Defaults false.
 #
 # Actions:
 #
@@ -14,15 +15,25 @@
 #
 class yum::plugin::versionlock (
   Enum['present', 'absent'] $ensure = 'present',
-  String                    $path   = '/etc/yum/pluginconf.d/versionlock.list'
+  String                    $path   = '/etc/yum/pluginconf.d/versionlock.list',
+  Boolean                   $clean  = false,
 ) {
+
   yum::plugin { 'versionlock':
     ensure  => $ensure,
   }
+
+  include ::yum::clean
+  $_clean_notify = $clean ? {
+    true  => Exec['yum_clean_all'],
+    false => undef,
+  }
+
   concat { $path:
-    mode  => '0644',
-    owner => 'root',
-    group => 'root',
+    mode   => '0644',
+    owner  => 'root',
+    group  => 'root',
+    notify => $_clean_notify,
   }
 
   concat::fragment { 'versionlock_header':

--- a/spec/acceptance/define_versionlock_spec.rb
+++ b/spec/acceptance/define_versionlock_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper_acceptance'
+
+describe 'yum::versionlock define' do
+  context 'default parameters' do
+    # Using puppet_apply as a helper
+    it 'must work idempotently with no errors' do
+      pp = <<-EOS
+      yum::versionlock{ '0:bash-4.1.2-9.el6_2.*':
+        ensure => present,
+      }
+      yum::versionlock{ '0:tcsh-3.1.2-9.el6_2.*':
+        ensure => present,
+      }
+      EOS
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes:  true)
+    end
+    describe file('/etc/yum/pluginconf.d/versionlock.list') do
+      it { is_expected.to be_file }
+      it { is_expected.to contain '0:bash-4.1.2-9.el6_2.*' }
+      it { is_expected.to contain '0:tcsh-3.1.2-9.el6_2.*' }
+    end
+  end
+  it 'must work if clean is specified' do
+    shell('yum repolist', acceptable_exit_codes: [0])
+    pp = <<-EOS
+    class{yum::plugin::versionlock:
+      clean => true,
+    }
+    yum::versionlock{ '0:bash-3.1.2-9.el6_2.*':
+      ensure  => present,
+    }
+    EOS
+    # Run it twice and test for idempotency
+    apply_manifest(pp, catch_failures: true)
+    apply_manifest(pp, catch_changes:  true)
+    # Check the cache is really empty.
+    # all repos will have 0 packages.
+    shell('yum -C repolist -d0 | grep -v "repo id"  | awk "{print $NF}" FS=  | grep -v 0', acceptable_exit_codes: [1])
+  end
+end

--- a/spec/defines/versionlock_spec.rb
+++ b/spec/defines/versionlock_spec.rb
@@ -12,8 +12,16 @@ describe 'yum::versionlock' do
       it 'contains a well-formed Concat::Fragment' do
         is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("#{title}\n")
       end
+      it { is_expected.to contain_concat('/etc/yum/pluginconf.d/versionlock.list').without_notify }
     end
+    context 'clean set to true on module' do
+      let :pre_condition do
+        'class { "yum::plugin::versionlock": clean => true, }'
+      end
 
+      it { is_expected.to contain_concat('/etc/yum/pluginconf.d/versionlock.list').with_notify('Exec[yum_clean_all]') }
+      it { is_expected.to contain_exec('yum_clean_all').with_command('/usr/bin/yum clean all') }
+    end
     context 'and ensure set to present' do
       let(:params) { { ensure: 'present' } }
 


### PR DESCRIPTION
Currently when a versionlock entry is updated it has the unfortunate
problem that the cached yum repository metadata only contains
the previous locked files.

The class `yum::plugin::versionlock` now has a new option `clean`
defaulting to `false`. If true a `yum clean all` will exectuted
after the versionlock file is updated.

A new class `yum::clean` is added as it may be sensible
for some other operations to do the same.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
