### PR TITLE
Remove fastestmirror_enabled and report_instanceid parameters

### DIFF
--- a/data/os/RedHat/Amazon.yaml
+++ b/data/os/RedHat/Amazon.yaml
@@ -17,6 +17,12 @@ yum::os_default_repos:
   - 'epel-testing'
   - 'epel-testing-debuginfo'
   - 'epel-testing-source'
+
+# Upstream repo parameters "fastestmirror_enabled" and "report_instanceid"
+# not defined for Amazon Linux default repos as Puppet does not currently
+# support them. For more details, see:
+# https://tickets.puppetlabs.com/browse/PUP-8730
+# https://tickets.puppetlabs.com/browse/PUP-8904
 yum::repos:
   amzn-main:
     descr: "amzn-main-Base"
@@ -25,13 +31,11 @@ yum::repos:
     metadata_expire: 300
     priority: 10
     failovermethod: "priority"
-    fastestmirror_enabled: false
     gpgcheck: true
     gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-ga"
     enabled: true
     retries: 3
     timeout: 5
-    report_instanceid: true
     target: "/etc/yum.repos.d/amzn-main.repo"
   amzn-main-debuginfo:
     descr: "amzn-main-debuginfo"
@@ -40,13 +44,11 @@ yum::repos:
     metadata_expire: 300
     priority: 10
     failovermethod: "priority"
-    fastestmirror_enabled: false
     gpgcheck: true
     gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-ga"
     enabled: false
     retries: 3
     timeout: 5
-    report_instanceid: true
     target: "/etc/yum.repos.d/amzn-main.repo"
   amzn-main-source:
     descr: "amzn-main-source"
@@ -55,13 +57,11 @@ yum::repos:
     metadata_expire: 300
     priority: 10
     failovermethod: "priority"
-    fastestmirror_enabled: false
     gpgcheck: true
     gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-ga"
     enabled: false
     retries: 3
     timeout: 5
-    report_instanceid: true
     target: "/etc/yum.repos.d/amzn-main.repo"
   amzn-nosrc:
     descr: "amzn-nosrc-Base"
@@ -70,13 +70,11 @@ yum::repos:
     metadata_expire: 300
     priority: 10
     failovermethod: "priority"
-    fastestmirror_enabled: false
     gpgcheck: false
     gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-ga"
     enabled: false
     retries: 3
     timeout: 5
-    report_instanceid: true
     target: "/etc/yum.repos.d/amzn-nosrc.repo"
   amzn-preview:
     descr: "amzn-preview-Base"
@@ -85,13 +83,11 @@ yum::repos:
     metadata_expire: 300
     priority: 10
     failovermethod: "priority"
-    fastestmirror_enabled: false
     gpgcheck: true
     gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-ga"
     enabled: false
     retries: 3
     timeout: 5
-    report_instanceid: true
     target: "/etc/yum.repos.d/amzn-preview.repo"
   amzn-preview-debuginfo:
     descr: "amzn-preview-debuginfo"
@@ -100,13 +96,11 @@ yum::repos:
     metadata_expire: 300
     priority: 10
     failovermethod: "priority"
-    fastestmirror_enabled: false
     gpgcheck: true
     gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-ga"
     enabled: false
     retries: 3
     timeout: 5
-    report_instanceid: true
     target: "/etc/yum.repos.d/amzn-preview.repo"
   amzn-preview-source:
     descr: "amzn-preview-source"
@@ -115,13 +109,11 @@ yum::repos:
     metadata_expire: 300
     priority: 10
     failovermethod: "priority"
-    fastestmirror_enabled: false
     gpgcheck: true
     gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-ga"
     enabled: false
     retries: 3
     timeout: 5
-    report_instanceid: true
     target: "/etc/yum.repos.d/amzn-preview.repo"
   amzn-updates:
     descr: "amzn-updates-Base"
@@ -130,13 +122,11 @@ yum::repos:
     metadata_expire: 300
     priority: 10
     failovermethod: "priority"
-    fastestmirror_enabled: false
     gpgcheck: true
     gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-ga"
     enabled: true
     retries: 3
     timeout: 5
-    report_instanceid: true
     target: "/etc/yum.repos.d/amzn-updates.repo"
   amzn-updates-debuginfo:
     descr: "amzn-updates-debuginfo"
@@ -145,13 +135,11 @@ yum::repos:
     metadata_expire: 300
     priority: 10
     failovermethod: "priority"
-    fastestmirror_enabled: false
     gpgcheck: true
     gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-ga"
     enabled: false
     retries: 3
     timeout: 5
-    report_instanceid: true
     target: "/etc/yum.repos.d/amzn-updates.repo"
   amzn-updates-source:
     descr: "amzn-updates-source"
@@ -160,13 +148,11 @@ yum::repos:
     metadata_expire: 300
     priority: 10
     failovermethod: "priority"
-    fastestmirror_enabled: false
     gpgcheck: true
     gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-ga"
     enabled: false
     retries: 3
     timeout: 5
-    report_instanceid: true
     target: "/etc/yum.repos.d/amzn-updates.repo"
   epel:
     descr: "Extra Packages for Enterprise Linux 6 - $basearch"


### PR DESCRIPTION
#### Pull Request (PR) description
Remove the Amazon Linux default repository parameters fastestmirror_enabled and report_instanceid.

While report_instanceid is functional, fastestmirror_enabled is not functional. Neither parameter is supported by the Puppet Yumrepo type.

Puppetlabs has been approached (in https://tickets.puppetlabs.com/browse/PUP-8730) to add support for these parameters, however a decision has been made not to do this and instead to modify the Yumrepo type in Puppet 6 to allow for arbitrary parameters (https://tickets.puppetlabs.com/browse/PUP-8904).

Until such time as this issue is addressed in Puppet it is not possible to define these parameters to maintain parity with upstream and therefore they should be removed from this module. Otherwise the Default OS Repo functionality for Amazon Linux in this module cannot work at all.

#### This Pull Request (PR) fixes the following issues
Fixes #100 
