### PR TITLE
(#107) YUM update puppet task support

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,26 @@ yum::install { 'package-name':
 
 Please note that resource name must be same as installed package name.
 
+### Puppet tasks 
+
+The module has a puppet task that allows to run `yum update` or `yum upgrade`.
+Please refer to the [Bolt documentation](https://puppet.com/docs/bolt/latest/bolt.html) on how to execute a task.
+
+```bash
+$ bolt task show yum
+
+yum - Allows you to perform yum functions
+
+USAGE:
+bolt task run --nodes <node-name> yum action=<value> [quiet=<value>]
+
+PARAMETERS:
+- action: Enum['update', 'upgrade']
+    Action to perform 
+- quiet: Optional[Boolean]
+    Run without output 
+```
+
 ---
 
 This module was donated by CERIT Scientific Cloud, <support@cerit-sc.cz> to Vox Pupuli

--- a/tasks/init.json
+++ b/tasks/init.json
@@ -1,0 +1,14 @@
+{
+  "description": "Allows you to perform yum functions",
+  "input_method": "stdin",
+  "parameters": {
+    "action": {
+      "description": "Action to perform ",
+      "type": "Enum[update, upgrade]"
+    },
+    "quiet": {
+      "description": "Run without output ",
+      "type": "Optional[Boolean]"
+    }
+  }
+}

--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -1,0 +1,28 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+
+require 'json'
+require 'open3'
+require 'puppet'
+
+def yum(action, quiet)
+  cmd = ['yum', '-y']
+  cmd << '-q' unless quiet == false || quiet.nil?
+  cmd << action
+
+  stdout, stderr, status = Open3.capture3(*cmd)
+  raise Puppet::Error, stderr unless status.success?
+  { status: stdout.strip }
+end
+
+params = JSON.parse(STDIN.read)
+action = params['action']
+quiet = params['quiet']
+
+begin
+  result = yum(action, quiet)
+  puts result.to_json
+  exit 0
+rescue Puppet::Error => e
+  puts({ status: 'failure', error: e.message }.to_json)
+  exit 1
+end


### PR DESCRIPTION
#### Pull Request (PR) description

This adds a puppet task called yum that allows to run a yum update or
upgrade through bolt.

It also has a quiet parameter to run without output.

#### This Pull Request (PR) fixes the following issues
Fixes #107 

