### PR TITLE
Puppet 6 issue and knockout_prefix problem

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -10,7 +10,6 @@ lookup_options:
     yum::gpgkeys:
         merge:
             strategy: 'deep'
-            knockout_prefix: '--'
             merge_hash_arrays: true
     yum::managed_repos:
         merge: 'unique'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -207,7 +207,7 @@ class yum (
     default                  => '3',
   }
 
-  $_pc_cmd = delete_undef_values([
+  $_pc_cmd = [
     '/usr/bin/package-cleanup',
     '--oldkernels',
     "--count=${_real_installonly_limit}",
@@ -216,7 +216,7 @@ class yum (
       true    => '--keepdevel',
       default => undef,
     },
-  ])
+  ].filter |$val| { $val =~ NotUndef }
 
   exec { 'package-cleanup_oldkernels':
     command     => shellquote($_pc_cmd),


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    This PR fixes two issues: valid GPG key content being knocked out, and remove_undef_values not working in Puppet 6. As the remove_undef_values source indicates, the proper way to remove undefined values from a hash is to use a filter (which is what I've done).
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Fixes #111 
    Fixes #120
-->
