### PR TITLE
Correctly calculate rpmname for all gpg versions

### DIFF
--- a/manifests/gpgkey.pp
+++ b/manifests/gpgkey.pp
@@ -58,7 +58,10 @@ define yum::gpgkey (
     mode   => $mode,
   }
 
-  $rpmname = "gpg-pubkey-$(gpg ${path} | head -1 | cut -c12-20 | \
+  $rpmname = "gpg-pubkey-$(gpg --with-colons ${path} | \
+head -n 1 | \
+cut -d: -f5 | \
+cut -c9-16 | \
 tr '[A-Z]' '[a-z]')"
 
   case $ensure {

--- a/spec/defines/gpgkey_spec.rb
+++ b/spec/defines/gpgkey_spec.rb
@@ -11,7 +11,37 @@ describe 'yum::gpgkey' do
     let(:title) { '/test-key' }
     let(:params) { { content: 'a_non_empty_string' } }
 
-    it { is_expected.to compile.with_all_deps }
+    context 'with ensure = present' do
+      let(:params) do
+        super().merge(ensure: 'present')
+      end
+
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_exec("rpm-import-#{title}").with(
+          'path'    => '/bin:/usr/bin:/sbin/:/usr/sbin',
+          'command' => "rpm --import #{title}",
+          'unless'  => "rpm -q gpg-pubkey-$(gpg --with-colons #{title} | head -n 1 | cut -d: -f5 | cut -c9-16 | tr '[A-Z]' '[a-z]')",
+          'require' => "File[#{title}]"
+        )
+      }
+    end
+
+    context 'with ensure = absent' do
+      let(:params) do
+        super().merge(ensure: 'absent')
+      end
+
+      it { is_expected.to compile.with_all_deps }
+      it {
+        is_expected.to contain_exec("rpm-delete-#{title}").with(
+          'path'    => '/bin:/usr/bin:/sbin/:/usr/sbin',
+          'command' => "rpm -e gpg-pubkey-$(gpg --with-colons #{title} | head -n 1 | cut -d: -f5 | cut -c9-16 | tr '[A-Z]' '[a-z]')",
+          'onlyif'  => ["test -f #{title}", "rpm -q gpg-pubkey-$(gpg --with-colons #{title} | head -n 1 | cut -d: -f5 | cut -c9-16 | tr '[A-Z]' '[a-z]')"],
+          'before' => "File[#{title}]"
+        )
+      }
+    end
   end
 
   context 'with a source specified' do


### PR DESCRIPTION
#### Pull Request (PR) description

`ensure => present` for ``yum::gpgkey`` is inconsistent with newer versions of GPG (presumably starting with 2.2, but I have a limited sample size). Change has occured between 2.0.9 and 2.2.5.

#### Observed behaviour

##### GPG >2.2 (?)

```
hawking:~ # gpg --version
gpg (GnuPG) 2.2.5
libgcrypt 1.8.2
Copyright (C) 2018 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Home: /root/.gnupg
Supported algorithms:
Pubkey: RSA, ELG, DSA, ECDH, ECDSA, EDDSA
Cipher: IDEA, 3DES, CAST5, BLOWFISH, AES, AES192, AES256, TWOFISH,
        CAMELLIA128, CAMELLIA192, CAMELLIA256
Hash: SHA1, RIPEMD160, SHA256, SHA384, SHA512, SHA224
Compression: Uncompressed, ZIP, ZLIB, BZIP2
```

Current method:
```
hawking:~ # gpg /etc/pki/rpm-gpg/Puppet.key 2>/dev/null | head -1
pub   rsa4096 2016-08-18 [SC] [expires: 2021-08-17]
```

Proposed method:
```
hawking:~ # gpg --with-colons /etc/pki/rpm-gpg/Puppet.key 2>/dev/null | head -n 1 | cut -d: -f5
7F438280EF8D349F
```

##### GPG < 2.2

```
kepler:~ # gpg --version
gpg (GnuPG) 2.0.9
Copyright (C) 2008 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Home: ~/.gnupg
Supported algorithms:
Pubkey: RSA, ELG, DSA
Cipher: 3DES, CAST5, BLOWFISH, AES, AES192, AES256,
```

Current method:
```
kepler:~ # gpg /etc/pki/rpm-gpg/Puppet.key
pub  4096R/EF8D349F 2016-08-18 Puppet, Inc. Release Key (Puppet, Inc. Release Key) <release@puppet.com>
```

Proposed method:
```
kepler:~ # gpg --with-colons /etc/pki/rpm-gpg/Puppet.key 2>/dev/null | head -n 1 | cut -d: -f5
7F438280EF8D349F
```

#### This Pull Request (PR) fixes the following issues

Fixes #125