### PR TITLE
add requirement expression in metadata of task

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,8 @@ Please note that resource name must be same as installed package name.
 
 ### Puppet tasks
 
-The module has a puppet task that allows to run `yum update` or `yum upgrade`.
+The module has a puppet task that allows to run `yum update` or `yum upgrade`. This task needs puppet agent installed on the remote.
+
 Please refer to the [Bolt documentation](https://puppet.com/docs/bolt/latest/bolt.html) on how to execute a task.
 
 ```bash

--- a/tasks/init.json
+++ b/tasks/init.json
@@ -10,5 +10,11 @@
       "description": "Run without output ",
       "type": "Optional[Boolean]"
     }
-  }
+  },
+    "implementations": [
+      {
+        "name": "init.rb",
+        "requirements": ["puppet-agent"]
+      }
+    ]
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) descriptionly

The current task expect Puppet agent installed on the remote.

If it is missing on the remote we get the following error message :

```
 bolt task run yum action=update --nodes node1 --modulepath ./modules
Started on node1...
Failed on node1:
  The task failed with exit code 126:
  bash: /tmp/594417c7-c1ef-4956-b9ba-b07933580923/init.rb: /opt/puppetlabs/puppet/bin/ruby: bad interpreter: Aucun fichier ou dossier de ce type
 
  {
  }
Failed on 1 node: node1
Ran on 1 node in 0.81 seconds
```

This PR add the expression of the requirement in bolt. This should permit to get a nicer error message:

```
bolt task run yum action=update --nodes node1 --modulepath ./modules
Started on node1...
Failed on node1:
  No suitable implementation of yum for node1
Failed on 1 node: node1
Ran on 1 node in 0.15 seconds
```
