### PR TITLE
Support ensuring all yum group packages are installed

### DIFF
--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -20,7 +20,7 @@
 #
 define yum::group (
   Array[String[1]]                                    $install_options = [],
-  Enum['present', 'installed', 'absent', 'purged'] $ensure             = 'present',
+  Enum['present', 'installed', 'latest', 'absent', 'purged'] $ensure   = 'present',
   Optional[Integer] $timeout                                           = undef,
 ) {
 
@@ -35,6 +35,14 @@ define yum::group (
         command => join(concat(["yum -y groupinstall '${name}'"], $install_options), ' '),
         unless  => "yum grouplist hidden '${name}' | egrep -i '^Installed.+Groups:$'",
         timeout => $timeout,
+      }
+      if $ensure == 'latest' {
+        exec { "yum-groupinstall-${name}-latest":
+          command => join(concat(["yum -y groupinstall '${name}'"], $install_options), ' '),
+          onlyif  => "yum groupinfo '${name}' | egrep '\\s+\\+'",
+          timeout => $timeout,
+          require => Exec["yum-groupinstall-${name}"],
+        }
       }
     }
 

--- a/spec/defines/group_spec.rb
+++ b/spec/defines/group_spec.rb
@@ -30,4 +30,13 @@ describe 'yum::group' do
     it { is_expected.to compile.with_all_deps }
     it { is_expected.to contain_exec("yum-groupinstall-#{title}").with_command("yum -y groupinstall 'Core' --enablerepo=epel") }
   end
+
+  context 'when ensure is set to `latest`' do
+    let(:title) { 'Core' }
+    let(:params) { { ensure: 'latest' } }
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_exec("yum-groupinstall-#{title}").with_command("yum -y groupinstall 'Core'") }
+    it { is_expected.to contain_exec("yum-groupinstall-#{title}-latest").with_command("yum -y groupinstall 'Core'") }
+  end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
Update `yum::group` to have additional state of `latest` that will ensure all mandatory packages of a group are always installed.

When a mandatory package is not installed for a group that is installed it will be prefixed with `+`. Without this change any changes to a mandatory package list would never get installed without manual intervention.

We use package groups to ensure baseline package list and it's much faster to apply one package group than dozens of individual Package resources.