### PR TITLE
Add support for yum facts (similar to the apt ones)

### DIFF
--- a/lib/facter/yum_reboot_required.rb
+++ b/lib/facter/yum_reboot_required.rb
@@ -1,0 +1,11 @@
+require 'English'
+
+Facter.add(:yum_reboot_required) do
+  confine osfamily: 'RedHat'
+  setcode do
+    if File.exist?('/usr/bin/needs-restarting')
+      Facter::Core::Execution.execute('/usr/bin/needs-restarting --reboothint')
+      !$CHILD_STATUS.success?
+    end
+  end
+end

--- a/lib/facter/yum_updates.rb
+++ b/lib/facter/yum_updates.rb
@@ -1,0 +1,37 @@
+Facter.add('yum_package_updates') do
+  confine osfamily: 'RedHat'
+  setcode do
+    yum_updates = []
+
+    if File.executable?('/usr/bin/yum')
+      yum_get_result = Facter::Util::Resolution.exec('/usr/bin/yum --assumeyes --quiet --cacheonly list updates')
+      unless yum_get_result.nil?
+        first_line = true
+        yum_get_result.each_line do |line|
+          if first_line
+            first_line = false
+            next
+          end
+          package, _available_version, _repository = line.split(%r{\s+})
+          yum_updates.push(package)
+        end
+      end
+    end
+
+    yum_updates
+  end
+end
+
+Facter.add('yum_has_updates') do
+  confine osfamily: 'RedHat'
+  setcode do
+    Facter.value(:yum_package_updates).any?
+  end
+end
+
+Facter.add('yum_updates') do
+  confine osfamily: 'RedHat'
+  setcode do
+    Facter.value(:yum_package_updates).length
+  end
+end

--- a/tasks/init.json
+++ b/tasks/init.json
@@ -4,7 +4,7 @@
   "parameters": {
     "action": {
       "description": "Action to perform ",
-      "type": "Enum[update, upgrade]"
+      "type": "Enum[update, upgrade, 'list updates']"
     },
     "quiet": {
       "description": "Run without output ",

--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -7,11 +7,27 @@ require 'puppet'
 def yum(action, quiet)
   cmd = ['yum', '-y']
   cmd << '-q' unless quiet == false || quiet.nil?
-  cmd << action
+  cmd += action.split(%r{\s+})
 
   stdout, stderr, status = Open3.capture3(*cmd)
   raise Puppet::Error, stderr unless status.success?
   { status: stdout.strip }
+end
+
+def process_list_updates(output)
+  status = output[:status].lines[1..-1]
+  status ||= []
+
+  result = status.map do |line|
+    package, available_version, repository = line.split(%r{\s+})
+    {
+      package: package,
+      available_version: available_version,
+      repository: repository
+    }
+  end
+
+  { status: result }
 end
 
 params = JSON.parse(STDIN.read)
@@ -20,6 +36,7 @@ quiet = params['quiet']
 
 begin
   result = yum(action, quiet)
+  result = process_list_updates(result) if action == 'list updates'
   puts result.to_json
   exit 0
 rescue Puppet::Error => e


### PR DESCRIPTION
#### Pull Request (PR) description
This PR add a bunch of facts similar to the ones provided by the [apt module](https://github.com/puppetlabs/puppetlabs-apt/blob/master/lib/facter/apt_updates.rb):

* `yum_has_updates` — `Boolean` indicating if updates are available;
* `yum_package_updates` — `Array[String]` list of upgradable packages;
* `yum_updates` — `Integer` number of upgradable packages;
* `yum_reboot_required` — `Boolean` indicating if the systems needs to be rebooted.

e.g.

```
% facter yum_has_updates yum_package_updates yum_reboot_required yum_updates
yum_has_updates => true
yum_package_updates => [
  "puppet-agent.x86_64"
]
yum_reboot_required => true
yum_updates => 1
```

```
% facter yum_has_updates yum_package_updates yum_reboot_required yum_updates
yum_has_updates => false
yum_package_updates => []
yum_reboot_required => false
yum_updates => 0
```

#### This Pull Request (PR) fixes the following issues
n/a