### PR TITLE
Support for DNF-based distros, and Fedora defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Module has been tested on:
 * CentOS 6, 7
 * Amazon Linux 2017
 * RHEL 7
+* Fedora 30 (partial support)
 
 ## Usage
 
@@ -358,6 +359,10 @@ PARAMETERS:
 - quiet: Optional[Boolean]
     Run without output
 ```
+
+### Fedora partial support
+
+Support for fedora is minimal at this time. The yum class can be included without error and resources such as `yum::group` can be managed. No repositories or GPG keys are managed by default. Old kernel cleanup is known not to work, and plugins may not work due to different package naming. Pull requests for additional support would be welcomed.
 
 ---
 

--- a/data/os/RedHat/Fedora.yaml
+++ b/data/os/RedHat/Fedora.yaml
@@ -1,0 +1,2 @@
+---
+yum::utils_package_name: "dnf-utils"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,6 +51,9 @@
 #   are referenced by a managed_repo. This will use the same merging behavior
 #   as repos.
 #
+# @param utils_package_name
+#   Name of the utils package, e.g. 'yum-utils', or 'dnf-utils'.
+#
 # @example Enable management of the default repos for a supported OS:
 #   ```yaml
 #   ---
@@ -110,6 +113,7 @@ class yum (
   Array[String] $os_default_repos = [],
   Array[String] $repo_exclusions = [],
   Hash[String, Hash[String, String]] $gpgkeys = {},
+  String $utils_package_name = 'yum-utils',
 ) {
 
   $module_metadata            = load_module_metadata($module_name)
@@ -199,7 +203,7 @@ class yum (
   }
 
   # cleanup old kernels
-  ensure_packages(['yum-utils'])
+  ensure_packages([$utils_package_name])
 
   $_real_installonly_limit = $config_options['installonly_limit'] ? {
     Variant[String, Integer] => $config_options['installonly_limit'],
@@ -221,7 +225,7 @@ class yum (
   exec { 'package-cleanup_oldkernels':
     command     => shellquote($_pc_cmd),
     refreshonly => true,
-    require     => Package['yum-utils'],
+    require     => Package[$utils_package_name],
     subscribe   => $_clean_old_kernels_subscribe,
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -57,6 +57,13 @@
       "operatingsystemrelease": [
         "2017"
       ]
+    },
+    {
+      "operatingsystem": "Fedora",
+      "operatingsystemrelease": [
+        "29",
+        "30"
+      ]
     }
   ],
   "requirements": [

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -279,6 +279,13 @@ describe 'yum' do
           it { is_expected.to contain_yum__gpgkey('/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6') }
         end
       end
+
+      context 'when utils_package_name is set' do
+        let(:params) { { utils_package_name: 'dnf-utils' } }
+        
+        it { is_expected.not_to contain_package('yum-utils') }
+        it { is_expected.to contain_package('dnf-utils') }
+      end
     end
   end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -9,7 +9,7 @@ shared_examples 'a Yum class' do |value|
     is_expected.to contain_exec('package-cleanup_oldkernels').with(
       command: "/usr/bin/package-cleanup --oldkernels --count=#{value} -y",
       refreshonly: true
-    ).that_requires('Package[yum-utils]').that_subscribes_to('Yum::Config[installonly_limit]')
+    ).that_subscribes_to('Yum::Config[installonly_limit]')
   end
 end
 
@@ -280,9 +280,18 @@ describe 'yum' do
         end
       end
 
+      context 'when utils_package_name is not set' do
+        case facts[:os]['name']
+        when 'Fedora'
+          it { is_expected.to contain_package('dnf-utils') }
+        else
+          it { is_expected.to contain_package('yum-utils') }
+        end
+      end
+
       context 'when utils_package_name is set' do
         let(:params) { { utils_package_name: 'dnf-utils' } }
-        
+
         it { is_expected.not_to contain_package('yum-utils') }
         it { is_expected.to contain_package('dnf-utils') }
       end


### PR DESCRIPTION
#### Pull Request (PR) description

* Adds support for overriding the utils package for DNF-based distributions where the utils package is `dnf-utils`
* Adds basic support for Fedora 29/30, by setting the utils package to `dnf-utils` in os-specific module data.

#### This Pull Request (PR) fixes the following issues

Related to #139 
