### PR TITLE
use $facts when accessing os fact

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -118,8 +118,8 @@ class yum (
     $os['operatingsystem']
   }
 
-  unless member($supported_os_names, $::os['name']) {
-    fail("${::os['name']} not supported")
+  unless member($supported_os_names, $facts['os']['name']) {
+    fail("${facts['os']['name']} not supported")
   }
 
   $_managed_repos = $manage_os_default_repos ? {

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -23,7 +23,7 @@ define yum::plugin (
   if $pkg_prefix {
     $_pkg_prefix = $pkg_prefix
   } else {
-    $_pkg_prefix = $::os['release']['major'] ? {
+    $_pkg_prefix = $facts['os']['release']['major'] ? {
       Variant[Integer[5,5], Enum['5']] => 'yum',
       default                          => 'yum-plugin',
     }


### PR DESCRIPTION
#### Pull Request (PR) description

access `os` facts thru the global `facts` variable

#### This Pull Request (PR) fixes the following issues

I've seen test failures in dependent modules, so I'd like to plug that hole!