### PR TITLE
add 'VirtuozzoLinux' support

### DIFF
--- a/data/os/RedHat/VirtuozzoLinux/6.yaml
+++ b/data/os/RedHat/VirtuozzoLinux/6.yaml
@@ -1,0 +1,98 @@
+# VirtuozzoLinux 6 default repos
+---
+yum::os_default_repos:
+  - 'virtuozzolinux-base'
+  - 'virtuozzolinux-updates'
+  - 'virtuozzolinux-base-debuginfo'
+  - 'virtuozzolinux-updates-debuginfo'
+  - 'virtuozzo'
+  - 'virtuozzo-updates'
+  - 'virtuozzo-debuginfo'
+  - 'ez-templates'
+  - 'ez-templates-32'
+  - 'obsoleted-ez-templates'
+  - 'obsoleted-ez-templates-32'
+
+yum::repos:
+  virtuozzolinux-base:
+    descr: "VirtuozzoLinux - Base"
+    #mirrorlist: "http://repo.virtuozzolinux.com/virtuozzolinux/mirrorlists/virtuozzolinux-$releasever-$basearch-os.mirrorlist"
+    mirrorlist: "http://repo.virtuozzo.com/vzlinux/mirrorlist/mirrors-6-os"
+    #baseurl: "http://repo.virtuozzo.com/vzlinux/6/$basearch/os/"
+    enabled: true
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/PARALLELS_GPG_KEY"
+    target: "/etc/yum.repos.d/virtuozzolinux-base.repo"
+  virtuozzolinux-updates:
+    descr: "VirtuozzoLinux - Updates"
+    mirrorlist: "http://repo.virtuozzo.com/vzlinux/mirrorlist/mirrors-6-updates"
+    #baseurl: "http://repo.virtuozzo.com/vzlinux/6/$basearch/updates/"
+    enabled: true
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/PARALLELS_GPG_KEY"
+    target: "/etc/yum.repos.d/virtuozzolinux-updates.repo"
+  virtuozzolinux-base-debuginfo:
+    descr: "VirtuozzoLinux - Base Debug"
+    mirrorlist: "http://repo.virtuozzo.com/vzlinux/mirrorlist/mirrors-6-os-debug"
+    #baseurl: "http://repo.virtuozzo.com/vzlinux/6/$basearch/debug/"
+    enabled: false
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/PARALLELS_GPG_KEY"
+    target: "/etc/yum.repos.d/virtuozzolinux-base-debuginfo.repo"
+  virtuozzolinux-updates-debuginfo:
+    descr: "VirtuozzoLinux - Updates Debug"
+    mirrorlist: "http://repo.virtuozzo.com/vzlinux/mirrorlist/mirrors-6-updates-debug"
+    #baseurl: "http://repo.virtuozzo.com/vzlinux/6/$basearch/debug_updates/"
+    enabled: false
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/PARALLELS_GPG_KEY"
+    target: "/etc/yum.repos.d/virtuozzolinux-updates-debuginfo.repo"
+  virtuozzo:
+    descr: "Virtuozzo Base"
+    mirrorlist: "http://updates.virtuozzo.com/mirrors/cloudserver/6.0/base"
+    enabled: true
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/PARALLELS_GPG_KEY"
+    target: "/etc/yum.repos.d/virtuozzo.repo"
+  virtuozzo-updates:
+    descr: "Virtuozzo Updates"
+    mirrorlist: "http://updates.virtuozzo.com/mirrors/cloudserver/6.0/updates"
+    enabled: true
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/PARALLELS_GPG_KEY"
+    target: "/etc/yum.repos.d/virtuozzo-updates.repo"
+  virtuozzo-debuginfo:
+    descr: "Virtuozzo Debug and Devel packages"
+    mirrorlist: "http://updates.virtuozzo.com/mirrors/cloudserver/6.0/debug"
+    enabled: false
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/PARALLELS_GPG_KEY"
+    target: "/etc/yum.repos.d/virtuozzo-debuginfo.repo"
+  ez-templates:
+    descr: "Virtuozzo - EZ templates"
+    mirrorlist: "http://updates.virtuozzo.com/mirrors/templates-x86_64"
+    enabled: true
+    gpgcheck: false
+    gpgkey: "file:///etc/pki/rpm-gpg/PARALLELS_GPG_KEY"
+    target: "/etc/yum.repos.d/ez-templates.repo"
+  ez-templates-32:
+    descr: "Virtuozzo - EZ templates (32 bits)"
+    mirrorlist: "http://updates.virtuozzo.com/mirrors/templates-i386"
+    enabled: true
+    gpgcheck: false
+    gpgkey: "file:///etc/pki/rpm-gpg/PARALLELS_GPG_KEY"
+    target: "/etc/yum.repos.d/ez-templates-32.repo"
+  obsoleted-ez-templates:
+    descr: "Virtuozzo - obsoleted EZ templates"
+    mirrorlist: "http://updates.virtuozzo.com/mirrors/obsoleted-templates-x86_64"
+    enabled: false
+    gpgcheck: false
+    gpgkey: "file:///etc/pki/rpm-gpg/PARALLELS_GPG_KEY"
+    target: "/etc/yum.repos.d/obsoleted-ez-templates.repo"
+  obsoleted-ez-templates-32:
+    descr: "Virtuozzo - obsoleted EZ templates (32 bits)"
+    mirrorlist: "http://updates.virtuozzo.com/mirrors/obsoleted-templates-i386"
+    enabled: false
+    gpgcheck: false
+    gpgkey: "file:///etc/pki/rpm-gpg/PARALLELS_GPG_KEY"
+    target: "/etc/yum.repos.d/obsoleted-ez-templates-32.repo"

--- a/data/os/RedHat/VirtuozzoLinux/7.yaml
+++ b/data/os/RedHat/VirtuozzoLinux/7.yaml
@@ -1,0 +1,163 @@
+# VirtuozzoLinux 7 default repos
+---
+# original comment regarding -factory repositories:
+#
+#   These -factory repositories are for internal use by developers only
+#   Enable them on your own risk!!!
+#
+yum::os_default_repos:
+  - 'virtuozzolinux-base'
+  - 'virtuozzolinux-updates'
+  - 'virtuozzolinux-base-debuginfo'
+  - 'virtuozzolinux-updates-debuginfo'
+  - 'virtuozzolinux-factory'
+  - 'virtuozzolinux-factory-debuginfo'
+  - 'virtuozzo-os'
+  - 'virtuozzo-updates'
+  - 'virtuozzo-os-debuginfo'
+  - 'virtuozzo-updates-debuginfo'
+  - 'virtuozzo-readykernel'
+  - 'obsoleted_tmpls'
+  - 'factory'
+  - 'factory-debuginfo'
+  - 'virtuozzolinux-vz-factory'
+  - 'virtuozzolinux-vz-factory-debuginfo'
+
+yum::repos:
+  virtuozzolinux-base:
+    descr: "VirtuozzoLinux Base"
+    mirrorlist: "http://repo.virtuozzo.com/vzlinux/mirrorlist/mirrors-7-os"
+    #baseurl: "http://repo.virtuozzo.com/vzlinux/7/$basearch/os/"
+    enabled: true
+    gpgcheck: true
+    priority: "90"
+    gpgkey:
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Virtuozzo-7"
+    target: "/etc/yum.repos.d/virtuozzolinux-base.repo"
+  virtuozzolinux-updates:
+    descr: "VirtuozzoLinux Updates"
+    mirrorlist: "http://repo.virtuozzo.com/vzlinux/mirrorlist/mirrors-7-updates"
+    #baseurl: "http://repo.virtuozzo.com/vzlinux/7/$basearch/updates/"
+    enabled: true
+    gpgcheck: true
+    priority: "90"
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Virtuozzo-7"
+    target: "/etc/yum.repos.d/virtuozzolinux-updates.repo"
+  virtuozzolinux-base-debuginfo:
+    descr: "VirtuozzoLinux Base debug packages"
+    mirrorlist: "http://repo.virtuozzo.com/vzlinux/mirrorlist/mirrors-7-os-debug"
+    #baseurl: "http://repo.virtuozzo.com/vzlinux/7/$basearch/debug/"
+    enabled: false
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Virtuozzo-7"
+    target: "/etc/yum.repos.d/virtuozzolinux-base-debuginfo.repo"
+  virtuozzolinux-updates-debuginfo:
+    descr: "VirtuozzoLinux Updates debug packages"
+    mirrorlist: "http://repo.virtuozzo.com/vzlinux/mirrorlist/mirrors-7-updates-debug"
+    #baseurl: "http://repo.virtuozzo.com/vzlinux/7/$basearch/updates-debug/"
+    enabled: false
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Virtuozzo-7"
+    target: "/etc/yum.repos.d/virtuozzolinux-updates-debuginfo.repo"
+  virtuozzolinux-factory:
+    descr: "VirtuozzoLinux Factory"
+    mirrorlist: "http://repo.virtuozzo.com/vzlinux/mirrorlist/mirrors-7-factory"
+    #baseurl: "http://repo.virtuozzo.com/vzlinux/7/$basearch/factory/"
+    priority: "90"
+    enabled: false
+    gpgcheck: false
+    target: "/etc/yum.repos.d/virtuozzolinux-factory.repo"
+  virtuozzolinux-factory-debuginfo:
+    descr: "VirtuozzoLinux Factory debug packages"
+    mirrorlist: "http://repo.virtuozzo.com/vzlinux/mirrorlist/mirrors-7-factory-debug"
+    #baseurl: "http://repo.virtuozzo.com/vzlinux/7/$basearch/factory-debug/"
+    priority: "90"
+    enabled: false
+    gpgcheck: false
+    target: "/etc/yum.repos.d/virtuozzolinux-factory-debuginfo.repo"
+  virtuozzo-os:
+    descr: "Virtuozzo"
+    mirrorlist: "http://repo.virtuozzo.com/vz/mirrorlists/7.0/releases-os.mirrorlist"
+    #baseurl: "http://repo.virtuozzo.com/vz/releases/7.0/x86_64/os/"
+    enabled: true
+    gpgcheck: true
+    priority: "50"
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Virtuozzo-7"
+    target: "/etc/yum.repos.d/virtuozzo-os.repo"
+  virtuozzo-updates:
+    descr: "Virtuozzo Updates"
+    mirrorlist: "http://repo.virtuozzo.com/vz/mirrorlists/7.0/updates-os.mirrorlist"
+    #baseurl: "http://repo.virtuozzo.com/vz/updates/7.0/x86_64/os/"
+    enabled: true
+    gpgcheck: true
+    priority: "50"
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Virtuozzo-7"
+    target: "/etc/yum.repos.d/virtuozzo-updates.repo"
+  virtuozzo-os-debuginfo:
+    descr: "Virtuozzo os Debug packages"
+    mirrorlist: "http://repo.virtuozzo.com/vz/mirrorlists/7.0/releases-debug.mirrorlist"
+    #baseurl: "http://repo.virtuozzo.com/vz/releases/7.0/x86_64/debug/"
+    enabled: false
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Virtuozzo-7"
+    target: "/etc/yum.repos.d/virtuozzo-os-debuginfo.repo"
+  virtuozzo-updates-debuginfo:
+    descr: "Virtuozzo updates Debug packages"
+    mirrorlist: "http://repo.virtuozzo.com/vz/mirrorlists/7.0/updates-debug.mirrorlist"
+    #baseurl: "http://repo.virtuozzo.com/vz/updates/7.0/x86_64/debug/"
+    enabled: false
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Virtuozzo-7"
+    target: "/etc/yum.repos.d/virtuozzo-updates-debuginfo.repo"
+  virtuozzo-readykernel:
+    descr: "Virtuozzo ReadyKernel"
+    baseurl: "https://appcatalog.virtuozzo.com/repo/readykernel-vz7/"
+    enabled: true
+    gpgcheck: true
+    priority: "50"
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Virtuozzo-7"
+    target: "/etc/yum.repos.d/virtuozzo-readykernel.repo"
+  obsoleted_tmpls:
+    descr: "Virtuozzo obsoleted EZ-templates"
+    mirrorlist: "http://repo.virtuozzo.com/vz/mirrorlists/7.0/obsoleted_tmpls.mirrorlist"
+    #baseurl: "http://repo.virtuozzo.com/vz/obsoleted_tmpls/7.0/x86_64/os/"
+    enabled: false
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Virtuozzo-7"
+    target: "/etc/yum.repos.d/obsoleted_tmpls.repo"
+  factory:
+    descr: "Build Factory packages for Containers"
+    mirrorlist: "http://download.openvz.org/virtuozzo/mirrorlists/7.0/factory-os.mirrorlist"
+    #baseurl: "http://download.openvz.org/virtuozzo/factory/x86_64/os/"
+    priority: "49"
+    enabled: false
+    gpgcheck: false
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Virtuozzo-7"
+    target: "/etc/yum.repos.d/factory.repo"
+  factory-debuginfo:
+    descr: "Debug packages for Containers from Build Factory"
+    mirrorlist: "http://download.openvz.org/virtuozzo/mirrorlists/7.0/factory-debug.mirrorlist"
+    #baseurl: "http://download.openvz.org/virtuozzo/factory/x86_64/debug/"
+    priority: "49"
+    enabled: false
+    gpgcheck: false
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Virtuozzo-7"
+    target: "/etc/yum.repos.d/factory-debuginfo.repo"
+  virtuozzolinux-vz-factory:
+    descr: "VirtuozzoLinux Factory"
+    mirrorlist: "http://repo.virtuozzo.com/vzlinux/mirrorlist/mirrors-7-factory"
+    #baseurl: "http://repo.virtuozzo.com/vzlinux/7/$basearch/factory/"
+    priority: "90"
+    enabled: false
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/VZLINUX_GPG_KEY"
+    target: "/etc/yum.repos.d/virtuozzolinux-vz-factory.repo"
+  virtuozzolinux-vz-factory-debuginfo:
+    descr: "VirtuozzoLinux Factory debug packages"
+    mirrorlist: "http://repo.virtuozzo.com/vzlinux/mirrorlist/mirrors-7-factory-debug"
+    #baseurl: "http://repo.virtuozzo.com/vzlinux/7/$basearch/factory-debug/"
+    priority: "90"
+    enabled: false
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/VZLINUX_GPG_KEY"
+    target: "/etc/yum.repos.d/virtuozzolinux-vz-factory-debuginfo.repo"

--- a/metadata.json
+++ b/metadata.json
@@ -53,6 +53,13 @@
       ]
     },
     {
+      "operatingsystem": "VirtuozzoLinux",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
       "operatingsystem": "Amazon",
       "operatingsystemrelease": [
         "2017"

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -62,7 +62,7 @@ describe 'yum' do
             it { is_expected.not_to contain_yumrepo('cr') }
           end
         when 'Amazon'
-          it { is_expected.to have_yumrepo_resource_count(16) }
+          it { is_expected.to have_yumrepo_resource_count(16) } # rubocop:disable RSpec/RepeatedExample
           it_behaves_like 'a catalog containing repos', [
             'amzn-main',
             'amzn-main-debuginfo',
@@ -103,6 +103,45 @@ describe 'yum' do
             'rhui-REGION-rhel-server-debug-supplementary',
             'rhui-REGION-rhel-server-source-supplementary'
           ]
+        when 'VirtuozzoLinux'
+          case facts[:os]['release']['major']
+          when '6'
+            it { is_expected.to have_yumrepo_resource_count(12) }
+            it_behaves_like 'a catalog containing repos', [
+              'virtuozzolinux-base',
+              'virtuozzolinux-updates',
+              'virtuozzolinux-base-debuginfo',
+              'virtuozzolinux-updates-debuginfo',
+              'virtuozzolinux-factory',
+              'virtuozzolinux-factory-debuginfo',
+              'virtuozzo-os',
+              'virtuozzo-updates',
+              'virtuozzo-os-debuginfo',
+              'virtuozzo-updates-debuginfo',
+              'virtuozzo-readykernel',
+              'obsoleted_tmpls'
+            ]
+          when '7'
+            it { is_expected.to have_yumrepo_resource_count(16) } # rubocop:disable RSpec/RepeatedExample
+            it_behaves_like 'a catalog containing repos', [
+              'virtuozzolinux-base',
+              'virtuozzolinux-updates',
+              'virtuozzolinux-base-debuginfo',
+              'virtuozzolinux-updates-debuginfo',
+              'virtuozzolinux-factory',
+              'virtuozzolinux-factory-debuginfo',
+              'virtuozzo-os',
+              'virtuozzo-updates',
+              'virtuozzo-os-debuginfo',
+              'virtuozzo-updates-debuginfo',
+              'virtuozzo-readykernel',
+              'obsoleted_tmpls',
+              'factory',
+              'factory-debuginfo',
+              'virtuozzolinux-vz-factory',
+              'virtuozzolinux-vz-factory-debuginfo'
+            ]
+          end
         else
           it { is_expected.to have_yumrepo_resource_count(0) }
         end
@@ -124,7 +163,7 @@ describe 'yum' do
               'centos-media'
             ]
           when 'Amazon'
-            it { is_expected.to have_yumrepo_resource_count(16) }
+            it { is_expected.to have_yumrepo_resource_count(16) } # rubocop:disable RSpec/RepeatedExample
             it_behaves_like 'a catalog containing repos', [
               'amzn-main',
               'amzn-main-debuginfo',
@@ -165,6 +204,45 @@ describe 'yum' do
               'rhui-REGION-rhel-server-debug-supplementary',
               'rhui-REGION-rhel-server-source-supplementary'
             ]
+          when 'VirtuozzoLinux'
+            case facts[:os]['release']['major']
+            when '6'
+              it { is_expected.to have_yumrepo_resource_count(12) }
+              it_behaves_like 'a catalog containing repos', [
+                'virtuozzolinux-base',
+                'virtuozzolinux-updates',
+                'virtuozzolinux-base-debuginfo',
+                'virtuozzolinux-updates-debuginfo',
+                'virtuozzolinux-factory',
+                'virtuozzolinux-factory-debuginfo',
+                'virtuozzo-os',
+                'virtuozzo-updates',
+                'virtuozzo-os-debuginfo',
+                'virtuozzo-updates-debuginfo',
+                'virtuozzo-readykernel',
+                'obsoleted_tmpls'
+              ]
+            when '7'
+              it { is_expected.to have_yumrepo_resource_count(16) } # rubocop:disable RSpec/RepeatedExample
+              it_behaves_like 'a catalog containing repos', [
+                'virtuozzolinux-base',
+                'virtuozzolinux-updates',
+                'virtuozzolinux-base-debuginfo',
+                'virtuozzolinux-updates-debuginfo',
+                'virtuozzolinux-factory',
+                'virtuozzolinux-factory-debuginfo',
+                'virtuozzo-os',
+                'virtuozzo-updates',
+                'virtuozzo-os-debuginfo',
+                'virtuozzo-updates-debuginfo',
+                'virtuozzo-readykernel',
+                'obsoleted_tmpls',
+                'factory',
+                'factory-debuginfo',
+                'virtuozzolinux-vz-factory',
+                'virtuozzolinux-vz-factory-debuginfo'
+              ]
+            end
           else
             it { is_expected.to have_yumrepo_resource_count(0) }
           end


### PR DESCRIPTION
`facter` 3.14 adds support for `os.name` *VirtuozzoLinux* (https://puppet.com/docs/puppet/latest/release_notes_facter.html). This means `os.name` won't resolve to *RedHat* anymore.