### PR TITLE
instantiate yumrepo & yum::config directly

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -133,8 +133,8 @@ class yum (
 
     $normalized_repos.each |$yumrepo, $attributes| {
       if member($_managed_repos_minus_exclusions, $yumrepo) {
-        Resource['yumrepo'] {
-          $yumrepo: * => $attributes,
+        yumrepo { $yumrepo:
+          * => $attributes,
         }
         # Handle GPG Key
         if ('gpgkey' in $attributes) {
@@ -183,8 +183,8 @@ class yum (
     }
 
     $_normalized_config_options.each |$config, $attributes| {
-      Resource['yum::config'] {
-        $config: * => $attributes,
+      yum::config { $config:
+        * => $attributes,
       }
     }
   }


### PR DESCRIPTION
#### Pull Request (PR) description

Since we're not doing any dynamic creation of potentially unknown
resources, we want to use `yumrepo` and `yum::config` directly, rather
than going thru `Resource`

#### This Pull Request (PR) fixes the following issues

none; only my confusion when reading the code.