### PR TITLE
`require` (not `contain`) yum::plugin::versionlock

### DIFF
--- a/manifests/versionlock.pp
+++ b/manifests/versionlock.pp
@@ -1,8 +1,14 @@
-# Define: yum::versionlock
+# @summary Locks package from updates.
 #
-# This definition locks package from updates.
+# @example Sample usage
+#   yum::versionlock { '0:bash-4.1.2-9.el6_2.*':
+#     ensure => present,
+#   }
 #
-# NOTE: The resource title must use the format
+# @param ensure
+#   Specifies if versionlock should be `present`, `absent` or `exclude`.
+#
+# @note The resource title must use the format
 #   "%{EPOCH}:%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}".  This can be retrieved via
 #   the command `rpm -q --qf '%{EPOCH}:%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}'.
 #   If "%{EPOCH}" returns as '(none)', it should be set to '0'.  Wildcards may
@@ -10,42 +16,25 @@
 #   '0:b*sh-4.1.2-9.*' covers Bash version 4.1.2, revision 9 on all
 #   architectures.
 #
-# Parameters:
-#   [*ensure*] - specifies if versionlock should be present, absent or exclude
-#
-# Actions:
-#
-# Requires:
-#   RPM based system, Yum versionlock plugin
-#
-# Sample usage:
-#   yum::versionlock { '0:bash-4.1.2-9.el6_2.*':
-#     ensure  => 'present',
-#   }
-#
+# @see http://man7.org/linux/man-pages/man1/yum-versionlock.1.html
 define yum::versionlock (
   Enum['present', 'absent', 'exclude'] $ensure = 'present',
 ) {
-  contain yum::plugin::versionlock
+  require yum::plugin::versionlock
 
-  unless $name.is_a(Yum::VersionlockString) {
-    fail('Package name must be formated as %{EPOCH}:%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}. See Yum::Versionlock documentation for details.')
+  assert_type(Yum::VersionlockString, $name) |$_expected, $actual | {
+    fail("Package name must be formatted as %{EPOCH}:%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}, not \'${actual}\'. See Yum::Versionlock documentation for details.")
   }
 
   $line_prefix = $ensure ? {
     'exclude' => '!',
-    default => '',
+    default   => '',
   }
 
-  case $ensure {
-    'present', 'exclude', default: {
-      concat::fragment { "yum-versionlock-${name}":
-        content => "${line_prefix}${name}\n",
-        target  => $yum::plugin::versionlock::path,
-      }
-    }
-    'absent':{
-      # fragment will be removed
+  unless $ensure == 'absent' {
+    concat::fragment { "yum-versionlock-${name}":
+      content => "${line_prefix}${name}\n",
+      target  => $yum::plugin::versionlock::path,
     }
   }
 }


### PR DESCRIPTION
The plugin class `yum::plugin::versionlock` should not be `contain`ed
from every instance of the `yum::versionlock` defined type. Doing so
makes it impossible to use the type in multiple dependent
classes/profiles. `contain` implies that the resource 'owns' the plugin.
Using `require` should be just as effective at solving #43 without
introducing dependency cycles.

With `contain`...

```puppet
class profile::foo {
  yum::versionlock { '0:bash-4.1.2-9.el6_2.*':}
}

class profile::bar {
  yum::versionlock { '2:vim-enhanced-7.4.629-6.el7.x86_64':}
}

include profile::foo
include profile::bar

Class['profile::foo'] -> Class['profile::bar']
```

fails with
```
Error: Found 1 dependency cycle:
(Augeas[yum.conf_plugins] => Yum::Config[plugins] => Yum::Plugin[versionlock] => Class[Yum::Plugin::Versionlock] => Yum::Versionlock[0:bash-4.1.2-9.el6_2.*] => Class[Profile::Foo] => Class[Profile::Bar] => Yum::Versionlock[2:vim-enhanced-7.4.629-6.el7.x86_64] => Class[Yum::Plugin::Versionlock] => Yum::Plugin[versionlock] => Package[yum-plugin-versionlock] => Yum::Plugin[versionlock])\nTry the '--graph' option and opening the resulting '.dot' file in OmniGraffle or GraphViz
Error: Failed to apply catalog: One or more resource dependency cycles detected in graph
```

This commit also refactors the type with:
  * puppet-strings style docs.
  * A simple `unless` instead of a `case` for `ensure`.
  * `assert_type` instead of `is_a`.

Fixes #43