### PR TITLE
don't install 'yum-utils' on CentOS 8

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -199,7 +199,12 @@ class yum (
   }
 
   # cleanup old kernels
-  ensure_packages(['yum-utils'])
+  if (($facts['os']['name'] == 'RedHat' or $facts['os']['name'] == 'CentOS') and $facts['os']['release']['major'] == '8') {
+    $clean_require = undef
+  } else {
+    ensure_packages(['yum-utils'])
+    $clean_require = Package[yum-utils]
+  }
 
   $_real_installonly_limit = $config_options['installonly_limit'] ? {
     Variant[String, Integer] => $config_options['installonly_limit'],
@@ -221,7 +226,7 @@ class yum (
   exec { 'package-cleanup_oldkernels':
     command     => shellquote($_pc_cmd),
     refreshonly => true,
-    require     => Package['yum-utils'],
+    require     => $clean_require,
     subscribe   => $_clean_old_kernels_subscribe,
   }
 }


### PR DESCRIPTION
Small patch for CentOS 8 support - don't try install yum-utils, which is no longer a package.  Other than this, the module appears to function ok on C8.  Probably needs more robust testing before adding it the supported operating systems list though.

Not the prettiest code in the world... Open to suggestions.