### PR TITLE
Fedora/CentOS8: Ensure yum-utils/dnf-utils are present

### DIFF
--- a/data/os/RedHat/Amazon/8.yaml
+++ b/data/os/RedHat/Amazon/8.yaml
@@ -1,2 +1,2 @@
 ---
-yum::utils_package_name: 'dnf-utils'
+yum::utils_package_name: 'yum-utils'

--- a/data/os/RedHat/Amazon/8.yaml
+++ b/data/os/RedHat/Amazon/8.yaml
@@ -1,2 +1,0 @@
----
-yum::utils_package_name: 'yum-utils'

--- a/data/os/RedHat/CentOS/8.yaml
+++ b/data/os/RedHat/CentOS/8.yaml
@@ -1,2 +1,2 @@
 ---
-yum::utils_package_name: 'dnf-utils'
+yum::utils_package_name: 'yum-utils'

--- a/data/os/RedHat/CentOS/8.yaml
+++ b/data/os/RedHat/CentOS/8.yaml
@@ -1,2 +1,0 @@
----
-yum::utils_package_name: 'yum-utils'

--- a/data/os/RedHat/RedHat/8.yaml
+++ b/data/os/RedHat/RedHat/8.yaml
@@ -1,2 +1,2 @@
 ---
-yum::utils_package_name: 'dnf-utils'
+yum::utils_package_name: 'yum-utils'

--- a/data/os/RedHat/RedHat/8.yaml
+++ b/data/os/RedHat/RedHat/8.yaml
@@ -1,2 +1,0 @@
----
-yum::utils_package_name: 'yum-utils'

--- a/data/os/RedHat/VirtuozzoLinux/8.yaml
+++ b/data/os/RedHat/VirtuozzoLinux/8.yaml
@@ -1,2 +1,2 @@
 ---
-yum::utils_package_name: 'dnf-utils'
+yum::utils_package_name: 'yum-utils'

--- a/data/os/RedHat/VirtuozzoLinux/8.yaml
+++ b/data/os/RedHat/VirtuozzoLinux/8.yaml
@@ -1,2 +1,0 @@
----
-yum::utils_package_name: 'yum-utils'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -363,13 +363,13 @@ describe 'yum' do
 
       context 'when utils_package_name is not set' do
         case facts[:os]['name']
-        when 'Fedora', 'RedHat', 'CentOS', 'Scientific', 'Amazon', 'OEL', 'OracleLinux', 'VirtuozzoLinux'
+        when 'Fedora'
           case facts[:os]['release']['major']
           when '27', '28', '29', '30', '31', '32'
             it { is_expected.to contain_package('dnf-utils') }
-          else
-            it { is_expected.to contain_package('yum-utils') }
           end
+        else
+          it { is_expected.to contain_package('yum-utils') }
         end
       end
       context 'when utils_package_name is set' do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -363,16 +363,15 @@ describe 'yum' do
 
       context 'when utils_package_name is not set' do
         case facts[:os]['name']
-        when 'Fedora', 'RedHat', 'CentOS', 'Scientific', 'Amazon', 'OEL', 'OracleLinux'
+        when 'Fedora', 'RedHat', 'CentOS', 'Scientific', 'Amazon', 'OEL', 'OracleLinux', 'VirtuozzoLinux'
           case facts[:os]['release']['major']
-          when '8', '27', '28', '29', '30', '31', '32'
+          when '27', '28', '29', '30', '31', '32'
             it { is_expected.to contain_package('dnf-utils') }
+          else
+            it { is_expected.to contain_package('yum-utils') }
           end
-        else
-          it { is_expected.to contain_package('yum-utils') }
         end
       end
-
       context 'when utils_package_name is set' do
         let(:params) { { utils_package_name: 'dnf-utils' } }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -364,10 +364,7 @@ describe 'yum' do
       context 'when utils_package_name is not set' do
         case facts[:os]['name']
         when 'Fedora'
-          case facts[:os]['release']['major']
-          when '27', '28', '29', '30', '31', '32'
-            it { is_expected.to contain_package('dnf-utils') }
-          end
+          it { is_expected.to contain_package('dnf-utils') }
         else
           it { is_expected.to contain_package('yum-utils') }
         end


### PR DESCRIPTION
#### Pull Request (PR) description
This PR will ensure that yum-utils gets installed on CentOS as unfortunately even on CentOS 8 this is still provided by yum-utils.

#### This Pull Request (PR) fixes the following issues
Fixes #158 