### PR TITLE
Fix yaml indentation inconsistency

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,19 +1,19 @@
 ---
 lookup_options:
-    yum::config_options:
-        merge: 'hash'
-    yum::repos:
-        merge:
-            strategy: 'deep'
-            knockout_prefix: '--'
-            merge_hash_arrays: true
-    yum::gpgkeys:
-        merge:
-            strategy: 'deep'
-            merge_hash_arrays: true
-    yum::managed_repos:
-        merge: 'unique'
-    yum::os_default_repos:
-        merge: 'unique'
-    yum::repo_exclusions:
-        merge: 'unique'
+  yum::config_options:
+    merge: 'hash'
+  yum::repos:
+    merge:
+      strategy: 'deep'
+      knockout_prefix: '--'
+      merge_hash_arrays: true
+  yum::gpgkeys:
+    merge:
+      strategy: 'deep'
+      merge_hash_arrays: true
+  yum::managed_repos:
+    merge: 'unique'
+  yum::os_default_repos:
+    merge: 'unique'
+  yum::repo_exclusions:
+    merge: 'unique'

--- a/data/os/RedHat/CentOS.yaml
+++ b/data/os/RedHat/CentOS.yaml
@@ -1,107 +1,107 @@
 ---
 yum::os_default_repos:
-    - 'base'
-    - 'updates'
-    - 'extras'
-    - 'centosplus'
-    - 'base-source'
-    - 'updates-source'
-    - 'extras-source'
-    - 'base-debuginfo'
-    - 'centos-media'
+  - 'base'
+  - 'updates'
+  - 'extras'
+  - 'centosplus'
+  - 'base-source'
+  - 'updates-source'
+  - 'extras-source'
+  - 'base-debuginfo'
+  - 'centos-media'
 yum::repos:
-    base:
-        enabled: true
-        descr: 'CentOS-$releasever - Base'
-        mirrorlist: 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra'
-        gpgcheck: true
-        gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-%{facts.os.release.major}"
-        target: '/etc/yum.repos.d/CentOS-Base.repo'
+  base:
+    enabled: true
+    descr: 'CentOS-$releasever - Base'
+    mirrorlist: 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra'
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-%{facts.os.release.major}"
+    target: '/etc/yum.repos.d/CentOS-Base.repo'
 
-    updates:
-        enabled: true
-        descr: 'CentOS-$releasever - Updates'
-        mirrorlist: 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra'
-        gpgcheck: true
-        gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-%{facts.os.release.major}"
-        target: '/etc/yum.repos.d/CentOS-Base.repo'
+  updates:
+    enabled: true
+    descr: 'CentOS-$releasever - Updates'
+    mirrorlist: 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra'
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-%{facts.os.release.major}"
+    target: '/etc/yum.repos.d/CentOS-Base.repo'
 
-    extras:
-        enabled: false
-        descr: 'CentOS-$releasever - Extras'
-        mirrorlist: 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra'
-        gpgcheck: true
-        gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-%{facts.os.release.major}"
-        target: '/etc/yum.repos.d/CentOS-Base.repo'
+  extras:
+    enabled: false
+    descr: 'CentOS-$releasever - Extras'
+    mirrorlist: 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra'
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-%{facts.os.release.major}"
+    target: '/etc/yum.repos.d/CentOS-Base.repo'
 
-    centosplus:
-        enabled: false
-        descr: 'CentOS-$releasever - Plus'
-        mirrorlist: 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus&infra=$infra'
-        gpgcheck: true
-        gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-%{facts.os.release.major}"
-        target: '/etc/yum.repos.d/CentOS-Base.repo'
+  centosplus:
+    enabled: false
+    descr: 'CentOS-$releasever - Plus'
+    mirrorlist: 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus&infra=$infra'
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-%{facts.os.release.major}"
+    target: '/etc/yum.repos.d/CentOS-Base.repo'
 
-    contrib:
-        enabled: false
-        descr: 'CentOS-$releasever - Contrib'
-        mirrorlist: 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib&infra=$infra'
-        gpgcheck: true
-        gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-%{facts.os.release.major}"
-        target: '/etc/yum.repos.d/CentOS-Base.repo'
+  contrib:
+    enabled: false
+    descr: 'CentOS-$releasever - Contrib'
+    mirrorlist: 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib&infra=$infra'
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-%{facts.os.release.major}"
+    target: '/etc/yum.repos.d/CentOS-Base.repo'
 
-    cr:
-        enabled: false
-        descr: 'CentOS-$releasever - cr'
-        baseurl: 'http://mirror.centos.org/centos/$releasever/cr/$basearch/'
-        gpgcheck: true
-        gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-%{facts.os.release.major}"
-        target: '/etc/yum.repos.d/CentOS-CR.repo'
+  cr:
+    enabled: false
+    descr: 'CentOS-$releasever - cr'
+    baseurl: 'http://mirror.centos.org/centos/$releasever/cr/$basearch/'
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-%{facts.os.release.major}"
+    target: '/etc/yum.repos.d/CentOS-CR.repo'
 
-    fasttrack:
-        enabled: false
-        descr: 'CentOS-$releasever - fasttrack'
-        mirrorlist: 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=fasttrack&infra=$infra'
-        gpgcheck: true
-        gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-%{facts.os.release.major}"
-        target: '/etc/yum.repos.d/CentOS-fasttrack.repo'
+  fasttrack:
+    enabled: false
+    descr: 'CentOS-$releasever - fasttrack'
+    mirrorlist: 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=fasttrack&infra=$infra'
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-%{facts.os.release.major}"
+    target: '/etc/yum.repos.d/CentOS-fasttrack.repo'
 
-    base-source:
-        enabled: false
-        descr: 'CentOS-$releasever - Base Sources'
-        baseurl: 'http://vault.centos.org/centos/$releasever/os/Source/'
-        gpgcheck: true
-        gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-%{facts.os.release.major}"
-        target: '/etc/yum.repos.d/CentOS-Sources.repo'
+  base-source:
+    enabled: false
+    descr: 'CentOS-$releasever - Base Sources'
+    baseurl: 'http://vault.centos.org/centos/$releasever/os/Source/'
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-%{facts.os.release.major}"
+    target: '/etc/yum.repos.d/CentOS-Sources.repo'
 
-    updates-source:
-        enabled: false
-        descr: 'CentOS-$releasever - Updates Sources'
-        baseurl: 'http://vault.centos.org/centos/$releasever/updates/Source/'
-        gpgcheck: true
-        gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-%{facts.os.release.major}"
-        target: '/etc/yum.repos.d/CentOS-Sources.repo'
+  updates-source:
+    enabled: false
+    descr: 'CentOS-$releasever - Updates Sources'
+    baseurl: 'http://vault.centos.org/centos/$releasever/updates/Source/'
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-%{facts.os.release.major}"
+    target: '/etc/yum.repos.d/CentOS-Sources.repo'
 
-    extras-source:
-        enabled: false
-        descr: 'CentOS-$releasever - Extras Sources'
-        baseurl: 'http://vault.centos.org/centos/$releasever/extras/Source/'
-        gpgcheck: true
-        gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-%{facts.os.release.major}"
-        target: '/etc/yum.repos.d/CentOS-Sources.repo'
+  extras-source:
+    enabled: false
+    descr: 'CentOS-$releasever - Extras Sources'
+    baseurl: 'http://vault.centos.org/centos/$releasever/extras/Source/'
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-%{facts.os.release.major}"
+    target: '/etc/yum.repos.d/CentOS-Sources.repo'
 
-    base-debuginfo:
-        enabled: false
-        descr: 'CentOS-$releasever - Debuginfo'
-        baseurl: 'http://debuginfo.centos.org/$releasever/$basearch/'
-        gpgcheck: true
-        gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Debug-%{facts.os.release.major}"
-        target: '/etc/yum.repos.d/CentOS-Debuginfo.repo'
+  base-debuginfo:
+    enabled: false
+    descr: 'CentOS-$releasever - Debuginfo'
+    baseurl: 'http://debuginfo.centos.org/$releasever/$basearch/'
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Debug-%{facts.os.release.major}"
+    target: '/etc/yum.repos.d/CentOS-Debuginfo.repo'
 
-    centos-media:
-        enabled: false
-        descr: 'CentOS-$releasever - Media'
-        baseurl: 'file:///media/CentOS/ file:///media/cdrom/ file:///media/cdrecorder/'
-        gpgcheck: true
-        gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-%{facts.os.release.major}"
-        target: '/etc/yum.repos.d/CentOS-Media.repo'
+  centos-media:
+    enabled: false
+    descr: 'CentOS-$releasever - Media'
+    baseurl: 'file:///media/CentOS/ file:///media/cdrom/ file:///media/cdrecorder/'
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-%{facts.os.release.major}"
+    target: '/etc/yum.repos.d/CentOS-Media.repo'

--- a/data/os/RedHat/CentOS/6.yaml
+++ b/data/os/RedHat/CentOS/6.yaml
@@ -1,3 +1,3 @@
 ---
 yum::os_default_repos:
-    - 'contrib'
+  - 'contrib'

--- a/data/os/RedHat/CentOS/7.yaml
+++ b/data/os/RedHat/CentOS/7.yaml
@@ -1,3 +1,3 @@
 ---
 yum::os_default_repos:
-    - 'cr'
+  - 'cr'

--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -1,54 +1,54 @@
 ---
 # This file contains miscellaneous, non-distro repositories.
 yum::repos:
-    # EPEL
-    epel:
-        descr: "Extra Packages for Enterprise Linux %{facts.os.release.major} - $basearch"
-        mirrorlist: "https://mirrors.fedoraproject.org/metalink?repo=epel-%{facts.os.release.major}&arch=$basearch"
-        failovermethod: 'priority'
-        enabled: true
-        gpgcheck: true
-        gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-%{facts.os.release.major}"
-        target: '/etc/yum.repos.d/epel.repo'
+  # EPEL
+  epel:
+    descr: "Extra Packages for Enterprise Linux %{facts.os.release.major} - $basearch"
+    mirrorlist: "https://mirrors.fedoraproject.org/metalink?repo=epel-%{facts.os.release.major}&arch=$basearch"
+    failovermethod: 'priority'
+    enabled: true
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-%{facts.os.release.major}"
+    target: '/etc/yum.repos.d/epel.repo'
 
-    epel-debuginfo:
-        descr: "Extra Packages for Enterprise Linux %{facts.os.release.major} - $basearch - Debug"
-        mirrorlist: "https://mirrors.fedoraproject.org/metalink?repo=epel-debug-%{facts.os.release.major}&arch=$basearch"
-        failovermethod: 'priority'
-        enabled: false
-        gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-%{facts.os.release.major}"
-        gpgcheck: true
-        target: '/etc/yum.repos.d/epel.repo'
+  epel-debuginfo:
+    descr: "Extra Packages for Enterprise Linux %{facts.os.release.major} - $basearch - Debug"
+    mirrorlist: "https://mirrors.fedoraproject.org/metalink?repo=epel-debug-%{facts.os.release.major}&arch=$basearch"
+    failovermethod: 'priority'
+    enabled: false
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-%{facts.os.release.major}"
+    gpgcheck: true
+    target: '/etc/yum.repos.d/epel.repo'
 
-    epel-source:
-        descr: "Extra Packages for Enterprise Linux %{facts.os.release.major} - $basearch - Source"
-        mirrorlist: "https://mirrors.fedoraproject.org/metalink?repo=epel-source-%{facts.os.release.major}&arch=$basearch"
-        failovermethod: 'priority'
-        enabled: false
-        gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-%{facts.os.release.major}"
-        gpgcheck: true
-        target: '/etc/yum.repos.d/epel.repo'
+  epel-source:
+    descr: "Extra Packages for Enterprise Linux %{facts.os.release.major} - $basearch - Source"
+    mirrorlist: "https://mirrors.fedoraproject.org/metalink?repo=epel-source-%{facts.os.release.major}&arch=$basearch"
+    failovermethod: 'priority'
+    enabled: false
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-%{facts.os.release.major}"
+    gpgcheck: true
+    target: '/etc/yum.repos.d/epel.repo'
 
-    epel-testing:
-        descr: "Extra Packages for Enterprise Linux %{facts.os.release.major} - Testing - $basearch"
-        mirrorlist: "https://mirrors.fedoraproject.org/metalink?repo=testing-epel%{facts.os.release.major}&arch=$basearch"
-        failovermethod: 'priority'
-        enabled: false
-        gpgcheck: true
-        gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-%{facts.os.release.major}"
+  epel-testing:
+    descr: "Extra Packages for Enterprise Linux %{facts.os.release.major} - Testing - $basearch"
+    mirrorlist: "https://mirrors.fedoraproject.org/metalink?repo=testing-epel%{facts.os.release.major}&arch=$basearch"
+    failovermethod: 'priority'
+    enabled: false
+    gpgcheck: true
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-%{facts.os.release.major}"
 
-    epel-testing-debuginfo:
-        descr: "Extra Packages for Enterprise Linux %{facts.os.release.major} - Testing - $basearch - Debug"
-        mirrorlist: "https://mirrors.fedoraproject.org/metalink?repo=testing-debug-epel%{facts.os.release.major}&arch=$basearch"
-        failovermethod: 'priority'
-        enabled: false
-        gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-%{facts.os.release.major}"
-        gpgcheck: true
+  epel-testing-debuginfo:
+    descr: "Extra Packages for Enterprise Linux %{facts.os.release.major} - Testing - $basearch - Debug"
+    mirrorlist: "https://mirrors.fedoraproject.org/metalink?repo=testing-debug-epel%{facts.os.release.major}&arch=$basearch"
+    failovermethod: 'priority'
+    enabled: false
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-%{facts.os.release.major}"
+    gpgcheck: true
 
-    epel-testing-source:
-        descr: "Extra Packages for Enterprise Linux %{facts.os.release.major} - Testing - $basearch - Source"
-        mirrorlist: "https://mirrors.fedoraproject.org/metalink?repo=testing-source-epel%{facts.os.release.major}&arch=$basearch"
-        failovermethod: 'priority'
-        enabled: false
-        gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-%{facts.os.release.major}"
-        gpgcheck: true
+  epel-testing-source:
+    descr: "Extra Packages for Enterprise Linux %{facts.os.release.major} - Testing - $basearch - Source"
+    mirrorlist: "https://mirrors.fedoraproject.org/metalink?repo=testing-source-epel%{facts.os.release.major}&arch=$basearch"
+    failovermethod: 'priority'
+    enabled: false
+    gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-%{facts.os.release.major}"
+    gpgcheck: true

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -6,16 +6,16 @@ defaults:
   data_hash: yaml_data
 
 hierarchy:
-    - name: 'OS Data'
-      paths:
-        - 'os/%{facts.os.family}/%{facts.os.name}/%{facts.os.release.full}.yaml'
-        - 'os/%{facts.os.family}/%{facts.os.name}/%{facts.os.release.major}/%{facts.os.release.minor}.yaml'
-        - 'os/%{facts.os.family}/%{facts.os.name}/%{facts.os.release.major}.yaml'
-        - 'os/%{facts.os.family}/%{facts.os.name}.yaml'
-        - 'os/%{facts.os.family}.yaml'
+  - name: 'OS Data'
+    paths:
+      - 'os/%{facts.os.family}/%{facts.os.name}/%{facts.os.release.full}.yaml'
+      - 'os/%{facts.os.family}/%{facts.os.name}/%{facts.os.release.major}/%{facts.os.release.minor}.yaml'
+      - 'os/%{facts.os.family}/%{facts.os.name}/%{facts.os.release.major}.yaml'
+      - 'os/%{facts.os.family}/%{facts.os.name}.yaml'
+      - 'os/%{facts.os.family}.yaml'
 
-    - name: 'Non-OS Yumrepos'
-      path: 'repos.yaml'
+  - name: 'Non-OS Yumrepos'
+    path: 'repos.yaml'
 
-    - name: 'Common Data'
-      path: 'common.yaml'
+  - name: 'Common Data'
+    path: 'common.yaml'


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes an inconsistency in the hiera.yaml indentation. Indentation should always be a consistent number of whitespaces.

I choose 2 whitespaces since it matches the general puppet [style guide](https://puppet.com/docs/puppet/latest/style_guide.html#spacing-indentation-and-whitespace). 

#### This Pull Request (PR) fixes the following issues
n/a