### PR TITLE
Support paramatized yum::versionlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,9 @@ yum::plugin { 'versionlock':
 ```
 
 ### Lock a package with the *versionlock* plugin
+The `versionlock` type changed between CentOS 7 and CentOS 8.
 
+#### CentOS 7 and older
 Locks explicitly specified packages from updates. Package name must be precisely
 specified in format *`EPOCH:NAME-VERSION-RELEASE.ARCH`*. Wild card in package
 name is allowed provided it does not span a field seperator.
@@ -335,6 +337,23 @@ class{'yum::plugin::versionlock':
 }
 yum::versionlock { '0:bash-4.1.2-9.el6_2.*':
   ensure => present,
+}
+```
+
+Note the CentOS 8 mechansim can be used if the parameter
+`version` is also set to anything other than the default `undef`. This allows
+common code to be used on CentOS  7 and 8 if the new style is used.
+
+#### CentOS 8 and newer
+Specify some of the version, release, epoch and arch values as parameters.
+
+```puppet
+yum::versionlock{'bash':
+  ensure => present,
+  version => '4.1.2',
+  release => '9.el8.2.*',
+  epoch   => 0,
+  arch    => 'x86_64',
 }
 ```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -24,6 +24,10 @@
 
 **Data types**
 
+* [`Yum::RpmArch`](#yumrpmarch): Valid rpm architectures.
+* [`Yum::RpmName`](#yumrpmname): Valid rpm name.
+* [`Yum::RpmRelease`](#yumrpmrelease): Valid rpm release fields.
+* [`Yum::RpmVersion`](#yumrpmversion): Valid rpm version fields.
 * [`Yum::VersionlockString`](#yumversionlockstring): This type matches strings appropriate for use with yum-versionlock. Its basic format, using the `rpm(8)` query string format, is `%{EPOCH}:%{
 
 **Tasks**
@@ -536,23 +540,51 @@ Default value: `undef`
 Locks package from updates.
 
 * **Note** The resource title must use the format
+By default on CentOS 7 the following format is used.
 "%{EPOCH}:%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}".  This can be retrieved via
 the command `rpm -q --qf '%{EPOCH}:%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}'.
 If "%{EPOCH}" returns as '(none)', it should be set to '0'.  Wildcards may
 be used within token slots, but must not cover seperators, e.g.,
 '0:b*sh-4.1.2-9.*' covers Bash version 4.1.2, revision 9 on all
 architectures.
+By default on CentOS 8 and newer the resource title  to just set the
+package name.
+If a version is set on CentOS 7 then it behaves like CentOS 8
 
 * **See also**
 http://man7.org/linux/man-pages/man1/yum-versionlock.1.html
 
 #### Examples
 
-##### Sample usage
+##### Sample usage on CentOS 7
 
 ```puppet
-yum::versionlock { '0:bash-4.1.2-9.el6_2.*':
+yum::versionlock { '0:bash-4.1.2-9.el7.*':
   ensure => present,
+}
+```
+
+##### Sample usage on CentOS 8
+
+```puppet
+yum::versionlock { 'bash':
+  ensure => present,
+  version => '4.1.2',
+  release => '9.el8',
+  epoch   => '0',
+  arch    => 'noarch',
+}
+```
+
+##### Sample usage on CentOS 7 with new style version, release, epoch, name parameters.
+
+```puppet
+yum::versionlock { 'bash':
+  ensure => present,
+  version => '3.1.2',
+  release => '9.el7',
+  epoch   => '0',
+  arch    => 'noarch',
 }
 ```
 
@@ -567,6 +599,39 @@ Data type: `Enum['present', 'absent', 'exclude']`
 Specifies if versionlock should be `present`, `absent` or `exclude`.
 
 Default value: 'present'
+
+##### `version`
+
+Data type: `Optional[Yum::RpmVersion]`
+
+Version of the package if CentOS 8 mechanism is used. This must be set for dnf based systems (e.g CentOS 8).
+If version is set then the name var is assumed to a package name and not the full versionlock string.
+
+Default value: `undef`
+
+##### `release`
+
+Data type: `Yum::RpmRelease`
+
+Release of the package if CentOS 8 mechanism is used.
+
+Default value: '*'
+
+##### `arch`
+
+Data type: `Optional[Variant[Yum::RpmArch, Enum['*']]]`
+
+Arch of the package if CentOS 8 mechanism is used.
+
+Default value: `undef`
+
+##### `epoch`
+
+Data type: `Integer[0]`
+
+Epoch of the package if CentOS 8 mechanism is used.
+
+Default value: 0
 
 ## Functions
 
@@ -641,6 +706,45 @@ Data type: `Hash`
 The hash on which to operate
 
 ## Data types
+
+### Yum::RpmArch
+
+Output of `rpm -q --queryformat '%{arch}\n' package`
+
+* **See also**
+https://github.com/rpm-software-management/rpm/blob/master/rpmrc.in
+
+Alias of `Enum['noarch', 'x86_64', 'i386', 'arm', 'ppc64', 'ppc64le', 'sparc64', 'ia64', 'alpha', 'ip', 'm68k', 'mips', 'mipsel', 'mk68k', 'mint', 'ppc', 'rs6000', 's390', 's390x', 'sh', 'sparc', 'xtensa']`
+
+### Yum::RpmName
+
+Can be alphanumeric or contain `.` `_` `+` `%` `{` `}` `-`.
+Output of `rpm -q --queryformat '%{name}\n package`
+Examples python36-foobar, netscape
+
+Alias of `Pattern[/\A([0-9a-zA-Z\._\+%\{\}-]+)\z/]`
+
+### Yum::RpmRelease
+
+It may not contain a dash.
+Output of `rpm -q --queryformat '%{release}\n' package`.
+Examples 3.4 3.4.el6, 3.4.el6_2
+
+* **See also**
+http://ftp.rpm.org/max-rpm/ch-rpm-file-format.html
+
+Alias of `Pattern[/\A^([^-]+)\z/]`
+
+### Yum::RpmVersion
+
+It may not contain a dash.
+Output of `rpm -q --queryformat '%{version}\n' package`.
+Examples 3.4, 2.5.alpha6
+
+* **See also**
+http://ftp.rpm.org/max-rpm/ch-rpm-file-format.html
+
+Alias of `Pattern[/\A([^-]+)\z/]`
 
 ### Yum::VersionlockString
 

--- a/manifests/versionlock.pp
+++ b/manifests/versionlock.pp
@@ -1,39 +1,106 @@
 # @summary Locks package from updates.
 #
-# @example Sample usage
-#   yum::versionlock { '0:bash-4.1.2-9.el6_2.*':
+# @example Sample usage on CentOS 7
+#   yum::versionlock { '0:bash-4.1.2-9.el7.*':
 #     ensure => present,
+#   }
+#
+# @example Sample usage on CentOS 8
+#   yum::versionlock { 'bash':
+#     ensure => present,
+#     version => '4.1.2',
+#     release => '9.el8',
+#     epoch   => '0',
+#     arch    => 'noarch',
+#   }
+#
+#
+# @example Sample usage on CentOS 7 with new style version, release, epoch, name parameters.
+#   yum::versionlock { 'bash':
+#     ensure => present,
+#     version => '3.1.2',
+#     release => '9.el7',
+#     epoch   => '0',
+#     arch    => 'noarch',
 #   }
 #
 # @param ensure
 #   Specifies if versionlock should be `present`, `absent` or `exclude`.
 #
+# @param version
+#   Version of the package if CentOS 8 mechanism is used. This must be set for dnf based systems (e.g CentOS 8).
+#   If version is set then the name var is assumed to a package name and not the full versionlock string.
+#
+# @param release
+#   Release of the package if CentOS 8 mechanism is used.
+#
+# @param arch
+#   Arch of the package if CentOS 8 mechanism is used.
+#
+# @param epoch
+#   Epoch of the package if CentOS 8 mechanism is used.
+#
 # @note The resource title must use the format
+#   By default on CentOS 7 the following format is used.
 #   "%{EPOCH}:%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}".  This can be retrieved via
 #   the command `rpm -q --qf '%{EPOCH}:%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}'.
 #   If "%{EPOCH}" returns as '(none)', it should be set to '0'.  Wildcards may
 #   be used within token slots, but must not cover seperators, e.g.,
 #   '0:b*sh-4.1.2-9.*' covers Bash version 4.1.2, revision 9 on all
 #   architectures.
+#   By default on CentOS 8 and newer the resource title  to just set the
+#   package name.
+#   If a version is set on CentOS 7 then it behaves like CentOS 8
 #
 # @see http://man7.org/linux/man-pages/man1/yum-versionlock.1.html
 define yum::versionlock (
-  Enum['present', 'absent', 'exclude'] $ensure = 'present',
+  Enum['present', 'absent', 'exclude']      $ensure  = 'present',
+  Optional[Yum::RpmVersion]                 $version = undef,
+  Yum::RpmRelease                           $release = '*',
+  Integer[0]                                $epoch   = 0,
+  Optional[Variant[Yum::RpmArch, Enum['*']]] $arch    = undef,
 ) {
   require yum::plugin::versionlock
-
-  assert_type(Yum::VersionlockString, $name) |$_expected, $actual | {
-    fail("Package name must be formatted as %{EPOCH}:%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}, not \'${actual}\'. See Yum::Versionlock documentation for details.")
-  }
 
   $line_prefix = $ensure ? {
     'exclude' => '!',
     default   => '',
   }
 
+  if $facts['package_provider'] == 'yum' and $version =~ Undef {
+
+    assert_type(Yum::VersionlockString, $name) |$_expected, $actual | {
+      fail("Package name must be formatted as %{EPOCH}:%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}, not \'${actual}\'. See Yum::Versionlock documentation for details.")
+    }
+
+    $_versionlock = "${line_prefix}${name}"
+
+  } else {
+
+    assert_type(Yum::RpmName, $name) |$_expected, $actual | {
+      fail("Package name must be formatted as Yum::RpmName, not \'${actual}\'. See Yum::Rpmname documentation for details.")
+    }
+
+    assert_type(Yum::RpmVersion, $version) |$_expected, $actual | {
+      fail("Version must be formatted as Yum::RpmVersion, not \'${actual}\'. See Yum::RpmVersion documentation for details.")
+    }
+
+    if $arch {
+      $_dotarch = ".${arch}"
+    } else {
+      $_dotarch = ''
+    }
+
+    $_versionlock = $facts['package_provider'] ? {
+      'yum'   => "${line_prefix}${epoch}:${name}-${version}-${release}${_dotarch}",
+      default => "${line_prefix}${name}-${epoch}:${version}-${release}${_dotarch}",
+    }
+
+  }
+
   unless $ensure == 'absent' {
     concat::fragment { "yum-versionlock-${name}":
-      content => "${line_prefix}${name}\n",
+      content => "${_versionlock}\n",
       target  => $yum::plugin::versionlock::path,
     }
   }

--- a/spec/defines/versionlock_spec.rb
+++ b/spec/defines/versionlock_spec.rb
@@ -1,82 +1,184 @@
 require 'spec_helper'
 
 describe 'yum::versionlock' do
-  let(:facts) { { os: { release: { major: 7 } } } }
+  context 'with package_provider set to yum' do
+    let(:facts) do
+      { os: { release: { major: 7 } },
+        package_provider: 'yum' }
+    end
 
-  context 'with a simple, well-formed title' do
-    let(:title) { '0:bash-4.1.2-9.el6_2.x86_64' }
+    context 'with a simple, well-formed title 0:bash-4.1.2-9.el6_2.x86_64' do
+      let(:title) { '0:bash-4.1.2-9.el6_2.x86_64' }
 
-    context 'and no parameters' do
+      context 'and no parameters' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_concat__fragment('versionlock_header').with_content("# File managed by puppet\n") }
+        it 'contains a well-formed Concat::Fragment' do
+          is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("#{title}\n")
+        end
+        it { is_expected.to contain_concat('/etc/yum/pluginconf.d/versionlock.list').without_notify }
+      end
+      context 'clean set to true on module' do
+        let :pre_condition do
+          'class { "yum::plugin::versionlock": clean => true, }'
+        end
+
+        it { is_expected.to contain_concat('/etc/yum/pluginconf.d/versionlock.list').with_notify('Exec[yum_clean_all]') }
+        it { is_expected.to contain_exec('yum_clean_all').with_command('/usr/bin/yum clean all') }
+      end
+
+      context 'and ensure set to present' do
+        let(:params) { { ensure: 'present' } }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_concat__fragment('versionlock_header').with_content("# File managed by puppet\n") }
+        it 'contains a well-formed Concat::Fragment' do
+          is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("#{title}\n")
+        end
+      end
+
+      context 'and ensure set to absent' do
+        let(:params) { { ensure: 'absent' } }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_concat__fragment('versionlock_header').with_content("# File managed by puppet\n") }
+        it 'contains a well-formed Concat::Fragment' do
+          is_expected.not_to contain_concat__fragment("yum-versionlock-#{title}")
+        end
+      end
+
+      context 'with version set namevar must be just a package name' do
+        let(:params) { { version: '4.3' } }
+
+        it { is_expected.to raise_error(Puppet::PreformattedError, %r{Package name must be formatted as Yum::RpmName, not 'String'}) }
+      end
+    end
+
+    context 'with a trailing wildcard title' do
+      let(:title) { '0:bash-4.1.2-9.el6_2.*' }
+
       it { is_expected.to compile.with_all_deps }
-      it { is_expected.to contain_concat__fragment('versionlock_header').with_content("# File managed by puppet\n") }
       it 'contains a well-formed Concat::Fragment' do
         is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("#{title}\n")
       end
-      it { is_expected.to contain_concat('/etc/yum/pluginconf.d/versionlock.list').without_notify }
     end
-    context 'clean set to true on module' do
-      let :pre_condition do
-        'class { "yum::plugin::versionlock": clean => true, }'
-      end
 
-      it { is_expected.to contain_concat('/etc/yum/pluginconf.d/versionlock.list').with_notify('Exec[yum_clean_all]') }
-      it { is_expected.to contain_exec('yum_clean_all').with_command('/usr/bin/yum clean all') }
-    end
-    context 'and ensure set to present' do
-      let(:params) { { ensure: 'present' } }
+    context 'with a complex wildcard title' do
+      let(:title) { '0:bash-4.*-*.el6' }
 
-      it { is_expected.to compile.with_all_deps }
-      it { is_expected.to contain_concat__fragment('versionlock_header').with_content("# File managed by puppet\n") }
       it 'contains a well-formed Concat::Fragment' do
         is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("#{title}\n")
       end
     end
 
-    context 'and ensure set to absent' do
-      let(:params) { { ensure: 'absent' } }
+    context 'with a release containing dots' do
+      let(:title) { '1:java-1.7.0-openjdk-1.7.0.121-2.6.8.0.el7_3.x86_64' }
 
-      it { is_expected.to compile.with_all_deps }
-      it { is_expected.to contain_concat__fragment('versionlock_header').with_content("# File managed by puppet\n") }
       it 'contains a well-formed Concat::Fragment' do
-        is_expected.not_to contain_concat__fragment("yum-versionlock-#{title}")
+        is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("#{title}\n")
+      end
+    end
+
+    context 'with an invalid title' do
+      let(:title) { 'bash-4.1.2' }
+
+      it { is_expected.to raise_error(Puppet::PreformattedError, %r(%\{EPOCH\}:%\{NAME\}-%\{VERSION\}-%\{RELEASE\}\.%\{ARCH\})) }
+    end
+
+    context 'with an invalid wildcard pattern' do
+      let(:title) { '0:bash-4.1.2*' }
+
+      it { is_expected.to raise_error(Puppet::PreformattedError, %r(%\{EPOCH\}:%\{NAME\}-%\{VERSION\}-%\{RELEASE\}\.%\{ARCH\})) }
+    end
+  end
+
+  context 'with a simple, well-formed package name title bash and a version' do
+    let(:facts) do
+      { os: { release: { major: 7 } },
+        package_provider: 'yum' }
+    end
+
+    let(:title) { 'bash' }
+
+    context 'with version set' do
+      it { is_expected.to compile.with_all_deps }
+      let(:params) { { version: '4.3' } }
+
+      it 'contains a well-formed Concat::Fragment' do
+        is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("0:bash-4.3-*\n")
+      end
+    end
+
+    context 'with version, release, epoch and arch set' do
+      it { is_expected.to compile.with_all_deps }
+      let(:params) do
+        {
+          version: '4.3',
+          release: '3.2',
+          arch: 'arm',
+          epoch: 42
+        }
+      end
+
+      it 'contains a well-formed Concat::Fragment' do
+        is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("42:bash-4.3-3.2.arm\n")
       end
     end
   end
 
-  context 'with a trailing wildcard title' do
-    let(:title) { '0:bash-4.1.2-9.el6_2.*' }
-
-    it { is_expected.to compile.with_all_deps }
-    it 'contains a well-formed Concat::Fragment' do
-      is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("#{title}\n")
+  context 'with package_provider set to dnf' do
+    let(:facts) do
+      { os: { release: { major: 8 } },
+        package_provider: 'dnf' }
     end
-  end
 
-  context 'with a complex wildcard title' do
-    let(:title) { '0:bash-4.*-*.el6' }
+    context 'with a simple, well-formed title, no version set' do
+      let(:title) { 'bash' }
 
-    it 'contains a well-formed Concat::Fragment' do
-      is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("#{title}\n")
+      it { is_expected.to raise_error(Puppet::PreformattedError, %r{Version must be formatted as Yum::RpmVersion}) }
+
+      context 'and a version set to 4.3' do
+        let(:params) { { version: '4.3' } }
+
+        it 'contains a well-formed Concat::Fragment' do
+          is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-0:4.3-*\n")
+        end
+        context 'and an arch set to x86_64' do
+          let(:params)  { super().merge(arch: 'x86_64') }
+
+          it 'contains a well-formed Concat::Fragment' do
+            is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-0:4.3-*.x86_64\n")
+          end
+        end
+        context 'and an release set to 22.x' do
+          let(:params) { super().merge(release: '22.5') }
+
+          it 'contains a well-formed Concat::Fragment' do
+            is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-0:4.3-22.5\n")
+          end
+        end
+        context 'and an epoch set to 5' do
+          let(:params) { super().merge(epoch: 5) }
+
+          it 'contains a well-formed Concat::Fragment' do
+            is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-5:4.3-*\n")
+          end
+        end
+      end
+      context 'with release, version, epoch, arch all set' do
+        let(:params) do
+          {
+            version: '22.5',
+            release: 'alpha12',
+            epoch: 8,
+            arch: 'i386'
+          }
+        end
+
+        it 'contains a well-formed Concat::Fragment' do
+          is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-8:22.5-alpha12.i386\n")
+        end
+      end
     end
-  end
-
-  context 'with a release containing dots' do
-    let(:title) { '1:java-1.7.0-openjdk-1.7.0.121-2.6.8.0.el7_3.x86_64' }
-
-    it 'contains a well-formed Concat::Fragment' do
-      is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("#{title}\n")
-    end
-  end
-
-  context 'with an invalid title' do
-    let(:title) { 'bash-4.1.2' }
-
-    it { is_expected.to raise_error(Puppet::PreformattedError, %r(%\{EPOCH\}:%\{NAME\}-%\{VERSION\}-%\{RELEASE\}\.%\{ARCH\})) }
-  end
-
-  context 'with an invalid wildcard pattern' do
-    let(:title) { '0:bash-4.1.2*' }
-
-    it { is_expected.to raise_error(Puppet::PreformattedError, %r(%\{EPOCH\}:%\{NAME\}-%\{VERSION\}-%\{RELEASE\}\.%\{ARCH\})) }
   end
 end

--- a/spec/type_aliases/yum_rpmarch_spec.rb
+++ b/spec/type_aliases/yum_rpmarch_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'Yum::Rpmarch' do
+  it { is_expected.to allow_value('x86_64') }
+  it { is_expected.to allow_value('noarch') }
+  it { is_expected.not_to allow_values('quantum') }
+end

--- a/spec/type_aliases/yum_rpmname_spec.rb
+++ b/spec/type_aliases/yum_rpmname_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe 'Yum::Rpmname' do
+  it { is_expected.to allow_value('python36-foobar') }
+  # confirmed that Name: puppet:agent is not permitted
+  # rpmbuild -bs ~/rpmbuild/SPECS/puppet\:agent.spec
+  # error: line 28: Illegal char ':' (0x3a) in: Name: puppet:agent
+  it { is_expected.not_to allow_values('puppet:agent') }
+end

--- a/spec/type_aliases/yum_rpmrelease_spec.rb
+++ b/spec/type_aliases/yum_rpmrelease_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe 'Yum::Rpmrelease' do
+  it { is_expected.to allow_value('3.2') }
+  it { is_expected.to allow_value('3.2alpha23') }
+  it { is_expected.to allow_value('3.2_alpha23') }
+  it { is_expected.to allow_value('3.2.el8') }
+  it { is_expected.to allow_value('3.2.el8_5') }
+  it { is_expected.not_to allow_values('4-3') }
+  it { is_expected.not_to allow_values('-3') }
+  it { is_expected.not_to allow_values('3-') }
+end

--- a/spec/type_aliases/yum_rpmversion_spec.rb
+++ b/spec/type_aliases/yum_rpmversion_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'Yum::Rpmversion' do
+  it { is_expected.to allow_value('3.2') }
+  it { is_expected.to allow_value('3.2alpha23') }
+  it { is_expected.to allow_value('3.2_alpha23') }
+  it { is_expected.not_to allow_values('4-3') }
+  it { is_expected.not_to allow_values('-3') }
+  it { is_expected.not_to allow_values('3-') }
+end

--- a/types/rpmarch.pp
+++ b/types/rpmarch.pp
@@ -1,0 +1,4 @@
+# @summary Valid rpm architectures.
+# Output of `rpm -q --queryformat '%{arch}\n' package`
+# @see https://github.com/rpm-software-management/rpm/blob/master/rpmrc.in
+type Yum::RpmArch  = Enum['noarch', 'x86_64', 'i386', 'arm', 'ppc64', 'ppc64le', 'sparc64', 'ia64' ,'alpha' , 'ip' , 'm68k', 'mips', 'mipsel' , 'mk68k' , 'mint' , 'ppc', 'rs6000' , 's390', 's390x' , 'sh', 'sparc', 'xtensa']

--- a/types/rpmname.pp
+++ b/types/rpmname.pp
@@ -1,0 +1,5 @@
+# @summary Valid rpm name.
+# Can be alphanumeric or contain `.` `_` `+` `%` `{` `}` `-`.
+# Output of `rpm -q --queryformat '%{name}\n package`
+# Examples python36-foobar, netscape
+type Yum::RpmName = Pattern[/\A([0-9a-zA-Z\._\+%\{\}-]+)\z/]

--- a/types/rpmrelease.pp
+++ b/types/rpmrelease.pp
@@ -1,0 +1,6 @@
+# @summary Valid rpm release fields.
+# It may not contain a dash.
+# Output of `rpm -q --queryformat '%{release}\n' package`.
+# Examples 3.4 3.4.el6, 3.4.el6_2
+# @see http://ftp.rpm.org/max-rpm/ch-rpm-file-format.html
+type Yum::RpmRelease = Pattern[/\A^([^-]+)\z/]

--- a/types/rpmversion.pp
+++ b/types/rpmversion.pp
@@ -1,0 +1,6 @@
+# @summary Valid rpm version fields.
+# It may not contain a dash.
+# Output of `rpm -q --queryformat '%{version}\n' package`.
+# Examples 3.4, 2.5.alpha6
+# @see http://ftp.rpm.org/max-rpm/ch-rpm-file-format.html
+type Yum::RpmVersion = Pattern[/\A([^-]+)\z/]


### PR DESCRIPTION
#### Pull Request (PR) description

Support paramatized yum::versionlock

Motivated by the change of format to the versionlock file with DNF systems
change `yum::versionlock` so it supports parameters `version`,
`release`, `epoch` and `arch`. If version is specified the namevar is now the package name.

So on a DNF based systemd (e.g CentOS 8) the following must be used.

```puppet
yum::versionlock{'bash':
  version => '3.4',
}
```

results in a version lock of on a dnf based system

```
bash-0:3.4-*
```

and on a yum based system of

```
0:bash-3.4-*
```

A fuller example with all parameters set.

```puppet
yum::versionlock{'bash':
  version  => '5.4',
  release  => 'alpha-rc3',
  epoch    => 8,
  arch     => 'noarch'
}
```

results in a version lock on a DNF based system of

```
bash-8:5.4-alpha-rc3.noarch
```

The same mechanism on YUM based systems (e.g CentOS 7) can be used.
To specify this new machanism at least a `version` should be set.

```puppet
yum::versionlock{'bash':
  version  => '5.4',
  release  => 'alpha-rc3',
  epoch    => 8,
  arch     => 'noarch'
  future   => true,
}
```

would results in

```
8:bash-5.4-alpha-rc3.noarch
```

as used by yum. If `version` is left default `undef`  then the old mechanism is used so this
is backwards compatable. e.g

```puppet
yum::versionlock{"0:bash-3.4-7.el8.x86_64"}
```
is still valid



#### This Pull Request (PR) fixes the following issues
Fixes #150

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
<!--
Replace this comment with a description of your pull request.
-->

<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
