### PR TITLE
Remove nested code blocks from string docs

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -41,39 +41,32 @@ A class to install and manage Yum configuration.
 ##### Enable management of the default repos for a supported OS:
 
 ```puppet
-```yaml
 ---
 yum::manage_os_default_repos: true
-```
 ```
 
 ##### Add Hiera data to disable *management* of the CentOS Base repo:
 
 ```puppet
-```yaml
 ---
 yum::manage_os_default_repos: true
 yum::repo_exclusions:
     - 'base'
 ```
-```
 
 ##### Ensure the CentOS base repo is removed from the agent system(s):
 
 ```puppet
-```yaml
 ---
 yum::manage_os_default_repos: true
 yum::repos:
     base:
         ensure: 'absent'
 ```
-```
 
 ##### Add a custom repo:
 
 ```puppet
-```yaml
 ---
 yum::managed_repos:
     - 'example_repo'
@@ -87,19 +80,16 @@ yum::repos:
         gpgkey: 'file:///etc/pki/gpm-gpg/RPM-GPG-KEY-Example'
         target: '/etc/yum.repos.d/example.repo'
 ```
-```
 
 ##### Use a custom `baseurl` for the CentOS Base repo:
 
 ```puppet
-```yaml
 ---
 yum::manage_os_default_repos: true
 yum::repos:
     base:
         baseurl: 'https://repos.example.com/CentOS/base/'
         mirrorlist: '--'
-```
 ```
 
 #### Parameters
@@ -595,7 +585,6 @@ be ignored, even if they contain Hashes.
 
 ```puppet
 
-```puppet
 Hash $foo = {
   bar => { 'a' => true, 'b' => 'b' },
   baz => false,
@@ -603,17 +592,14 @@ Hash $foo = {
 }
 
 yum::bool2num_hash_recursive($foo)
-```
 
 The above would return:
 
-```puppet
 {
   bar => { 'a' => 1, 'b' => 'b' },
   baz => 0,
   qux => [{ 'c' => true }, { 'd' => false }],
 }
-```
 ```
 
 #### `yum::bool2num_hash_recursive(Hash $arg)`
@@ -631,7 +617,6 @@ Returns: `Hash`
 
 ```puppet
 
-```puppet
 Hash $foo = {
   bar => { 'a' => true, 'b' => 'b' },
   baz => false,
@@ -639,17 +624,14 @@ Hash $foo = {
 }
 
 yum::bool2num_hash_recursive($foo)
-```
 
 The above would return:
 
-```puppet
 {
   bar => { 'a' => 1, 'b' => 'b' },
   baz => 0,
   qux => [{ 'c' => true }, { 'd' => false }],
 }
-```
 ```
 
 ##### `arg`
@@ -667,19 +649,19 @@ Its basic format, using the `rpm(8)` query string format, is
 `%{EPOCH}:%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}`.  As a Regex, it
 breaks down into five distinct parts, plus the seperators.
 
-  # EPOCH: An unsigned integer
+  EPOCH: An unsigned integer
   type Yum::PackageEpoch   = Regexp[/[0-9]\*]+/]
 
-  # NAME: Any valid package name (see https://github.com/rpm-software-management/rpm/blob/master/doc/manual/spec)
+  NAME: Any valid package name (see https://github.com/rpm-software-management/rpm/blob/master/doc/manual/spec)
   type Yum::PackageName    = Regexp[/[0-9a-zA-Z\._\+%\{\}\*-]+/]
 
-  # VERSION: Any valid version string. The only limitation here, according to the RPM manual, is that it may not contain a dash (`-`).
+  VERSION: Any valid version string. The only limitation here, according to the RPM manual, is that it may not contain a dash (`-`).
   type Yum::PackageVersion = Regexp[/[^-]+/]
 
-  # RELEASE: Any valid release string. Only limitation is that it is not a dash (`-`)
+  RELEASE: Any valid release string. Only limitation is that it is not a dash (`-`)
   type Yum::PackageRelease = Regexp[/[^-]+/]
 
-  # ARCH: Matches a string such as `el7.x86_64`.  This is actuall two sub-expressions.  See below.
+  ARCH: Matches a string such as `el7.x86_64`.  This is actuall two sub-expressions.  See below.
   type Yum::PackageArch    = Regexp[/([0-9a-zZ-Z_\*]+)(?:\.(noarch|x86_64|i386|arm|ppc64|ppc64le|sparc64|ia64|alpha|ip|m68k|mips|mipsel|mk68k|mint|ppc|rs6000|s390|s390x|sh|sparc|xtensa|\*))?/]
 
 The `%{ARCH}` sub-expression is composed of two sub-expressions
@@ -687,10 +669,10 @@ separated by a dot (`.`), where the second part is optional.  The RPM
 specification calls the first field the `DistTag`, and the second the
 `BuildArch`.
 
-   # DistTag: Any string consiting of only letters, numbers, or an underscore, e.g., `el6`, `sl7`, or `fc24`.
+   DistTag: Any string consiting of only letters, numbers, or an underscore, e.g., `el6`, `sl7`, or `fc24`.
    type Yum::PackageDistTag   = Regexp[/[0-9a-zZ-Z_\*]+/]
 
-   # BuildArch: Any string from the list at https://github.com/rpm-software-management/rpm/blob/master/rpmrc.in.  Strings are roughly listed from most common to least common to improve performance.
+   BuildArch: Any string from the list at https://github.com/rpm-software-management/rpm/blob/master/rpmrc.in.  Strings are roughly listed from most common to least common to improve performance.
    type Yum::PackageBuildArch = Regexp[/noarch|x86_64|i386|arm|ppc64|ppc64le|sparc64|ia64|alpha|ip|m68k|mips|mipsel|mk68k|mint|ppc|rs6000|s390|s390x|sh|sparc|xtensa/]
 
 wildcard characters may not span the fields, may not cover the
@@ -745,7 +727,7 @@ Allows you to perform yum functions
 
 ##### `action`
 
-Data type: `Enum[update, upgrade]`
+Data type: `Enum[update, upgrade, 'list updates']`
 
 Action to perform 
 

--- a/functions/bool2num_hash_recursive.pp
+++ b/functions/bool2num_hash_recursive.pp
@@ -10,7 +10,6 @@
 #
 # @example Usage
 #
-#   ```puppet
 #   Hash $foo = {
 #     bar => { 'a' => true, 'b' => 'b' },
 #     baz => false,
@@ -18,17 +17,14 @@
 #   }
 #
 #   yum::bool2num_hash_recursive($foo)
-#   ```
 #
 #   The above would return:
 #
-#   ```puppet
 #   {
 #     bar => { 'a' => 1, 'b' => 'b' },
 #     baz => 0,
 #     qux => [{ 'c' => true }, { 'd' => false }],
 #   }
-#   ```
 #
 function yum::bool2num_hash_recursive($arg) {
   assert_type(Hash, $arg)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,30 +55,23 @@
 #   Name of the utils package, e.g. 'yum-utils', or 'dnf-utils'.
 #
 # @example Enable management of the default repos for a supported OS:
-#   ```yaml
 #   ---
 #   yum::manage_os_default_repos: true
-#   ```
 #
 # @example Add Hiera data to disable *management* of the CentOS Base repo:
-#   ```yaml
 #   ---
 #   yum::manage_os_default_repos: true
 #   yum::repo_exclusions:
 #       - 'base'
-#   ```
 #
 # @example Ensure the CentOS base repo is removed from the agent system(s):
-#   ```yaml
 #   ---
 #   yum::manage_os_default_repos: true
 #   yum::repos:
 #       base:
 #           ensure: 'absent'
-#   ```
 #
 # @example Add a custom repo:
-#   ```yaml
 #   ---
 #   yum::managed_repos:
 #       - 'example_repo'
@@ -91,17 +84,14 @@
 #           gpgcheck: true
 #           gpgkey: 'file:///etc/pki/gpm-gpg/RPM-GPG-KEY-Example'
 #           target: '/etc/yum.repos.d/example.repo'
-#   ```
 #
 # @example Use a custom `baseurl` for the CentOS Base repo:
-#   ```yaml
 #   ---
 #   yum::manage_os_default_repos: true
 #   yum::repos:
 #       base:
 #           baseurl: 'https://repos.example.com/CentOS/base/'
 #           mirrorlist: '--'
-#   ```
 #
 class yum (
   Boolean $clean_old_kernels = true,

--- a/types/versionlockstring.pp
+++ b/types/versionlockstring.pp
@@ -3,19 +3,19 @@
 # `%{EPOCH}:%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}`.  As a Regex, it
 # breaks down into five distinct parts, plus the seperators.
 #
-#   # EPOCH: An unsigned integer
+#   EPOCH: An unsigned integer
 #   type Yum::PackageEpoch   = Regexp[/[0-9]\*]+/]
 #
-#   # NAME: Any valid package name (see https://github.com/rpm-software-management/rpm/blob/master/doc/manual/spec)
+#   NAME: Any valid package name (see https://github.com/rpm-software-management/rpm/blob/master/doc/manual/spec)
 #   type Yum::PackageName    = Regexp[/[0-9a-zA-Z\._\+%\{\}\*-]+/]
 #
-#   # VERSION: Any valid version string. The only limitation here, according to the RPM manual, is that it may not contain a dash (`-`).
+#   VERSION: Any valid version string. The only limitation here, according to the RPM manual, is that it may not contain a dash (`-`).
 #   type Yum::PackageVersion = Regexp[/[^-]+/]
 #
-#   # RELEASE: Any valid release string. Only limitation is that it is not a dash (`-`)
+#   RELEASE: Any valid release string. Only limitation is that it is not a dash (`-`)
 #   type Yum::PackageRelease = Regexp[/[^-]+/]
 #
-#   # ARCH: Matches a string such as `el7.x86_64`.  This is actuall two sub-expressions.  See below.
+#   ARCH: Matches a string such as `el7.x86_64`.  This is actuall two sub-expressions.  See below.
 #   type Yum::PackageArch    = Regexp[/([0-9a-zZ-Z_\*]+)(?:\.(noarch|x86_64|i386|arm|ppc64|ppc64le|sparc64|ia64|alpha|ip|m68k|mips|mipsel|mk68k|mint|ppc|rs6000|s390|s390x|sh|sparc|xtensa|\*))?/]
 #
 # The `%{ARCH}` sub-expression is composed of two sub-expressions
@@ -23,10 +23,10 @@
 # specification calls the first field the `DistTag`, and the second the
 # `BuildArch`.
 #
-#    # DistTag: Any string consiting of only letters, numbers, or an underscore, e.g., `el6`, `sl7`, or `fc24`.
+#    DistTag: Any string consiting of only letters, numbers, or an underscore, e.g., `el6`, `sl7`, or `fc24`.
 #    type Yum::PackageDistTag   = Regexp[/[0-9a-zZ-Z_\*]+/]
 #
-#    # BuildArch: Any string from the list at https://github.com/rpm-software-management/rpm/blob/master/rpmrc.in.  Strings are roughly listed from most common to least common to improve performance.
+#    BuildArch: Any string from the list at https://github.com/rpm-software-management/rpm/blob/master/rpmrc.in.  Strings are roughly listed from most common to least common to improve performance.
 #    type Yum::PackageBuildArch = Regexp[/noarch|x86_64|i386|arm|ppc64|ppc64le|sparc64|ia64|alpha|ip|m68k|mips|mipsel|mk68k|mint|ppc|rs6000|s390|s390x|sh|sparc|xtensa/]
 #
 # @note Each field may contain wildcard characters (`*`), but the


### PR DESCRIPTION
#### Pull Request (PR) description

REFERENCE.md was being created such that rendering was broken. In particular
it contained lots of nested code blocks of yaml inside puppet examples and
the 2nd half of the document was not being rendered at all.

Luckily rendering yaml as puppet code does not look bad.

#### This Pull Request (PR) fixes the following issues

