### PR TITLE
Enable and add CentOS 8 accept tests

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -2,6 +2,7 @@
   docker_sets:
   - set: centos6-64
   - set: centos7-64
+  - set: centos8-64
   secure: "iItNJ/PlMvdSiYjtXWJkS69mF/4XUriTRC6axFoiTgX8BzGNWA1U/anENNyzmhRKcH/Nc0erVeau+RX8vyJ0HmIJOCvYfq5Q/SQWex1fDXLe/UYJkAEWwmeIOVSF2nTEUPDvDn/d6bNEdULw5yrNn1dT8eLqIIXl6/nThdpiS917BX6CeYdojr/mISrLsvihuB5DQRdVzH+hK1bXcECihnOfNH9lQ0lZ2v2ohJiLJL0DadDg0YMMeJMlP7CnBZzRs7fhTPdLMjzCvysef9nqBYRlGBRUn+CaQ4VoQZlWB1JchJup4qCGeU9ANkb8gdKYTy1kFkBrEDuqlUUuuTTMhDpQ+2fGF32zgnXCSnVY8AIriFfO9c1ljxL6k6vaHpfnsPcMrxuQXNeOPGYpVjNGi/Hz8OjuZ3IT07c8SmZgmGaNp+ZIKErJQV0eob0NeA/1P7HheRS5aPEiN8vj/ZGuIGa+BhbTp2riJ599urrSqGDcJ0YzNeW2BvBZQoXs953X4N4yROz4xKMNqPz/jhyGM9w5SBJ/uLiIvKTu+bSsJ2VNyrOOu25eYqzH1zKc71fKiWa1ZOTHKVM24chlmoq3tZTSpSn6OxpptKLxAYZG0IUdFSMy66m8nss1AxL2djScAptugsqpfLqziMArAoN9iWXCeGiWz1qLRl+5AlMrmMY="
 spec/spec_helper_acceptance.rb:
   unmanaged: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,14 @@ matrix:
     bundler_args: --without development release
     env: BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=centos7-64 CHECK=beaker
     services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_setfile=centos8-64 CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=centos8-64 CHECK=beaker
+    services: docker
 branches:
   only:
   - master


### PR DESCRIPTION
#### Pull Request (PR) description
Correct acceptence tests for DNF (8) system

Use the new versionlock specification from #169 on CentOS 8.

Also test the new specification on 7 and 8 also.

Finally test that if samba-devel is filtered at
an impossible version it is no longer available.
For the yum case probably assumes that samba-devel is not installed.

