### PR TITLE
Use simpler code for tests for expected failures

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -289,8 +289,7 @@ describe 'yum' do
           let(:params) { { config_options: { 'installonly_limit' => false } } }
 
           it 'raises a useful error' do
-            is_expected.to raise_error(
-              Puppet::PreformattedError,
+            is_expected.to compile.and_raise_error(
               %r{The value or ensure for `\$yum::config_options\[installonly_limit\]` must be an Integer, but it is not\.}
             )
           end

--- a/spec/defines/config_spec.rb
+++ b/spec/defines/config_spec.rb
@@ -4,7 +4,7 @@ describe 'yum::config' do
   context 'with no parameters' do
     let(:title) { 'assumeyes' }
 
-    it { is_expected.to raise_error(Puppet::PreformattedError, %r{expects a value for parameter 'ensure'}) }
+    it { is_expected.to compile.and_raise_error(%r{expects a value for parameter 'ensure'}) }
   end
 
   context 'when ensure is a Boolean' do

--- a/spec/defines/gpgkey_spec.rb
+++ b/spec/defines/gpgkey_spec.rb
@@ -4,7 +4,7 @@ describe 'yum::gpgkey' do
   context 'with no parameters' do
     let(:title) { '/test-key' }
 
-    it { is_expected.to raise_error(Puppet::PreformattedError, %r{Missing params: \$content or \$source must be specified}) }
+    it { is_expected.to compile.and_raise_error(%r{Missing params: \$content or \$source must be specified}) }
   end
 
   context 'with content provided' do
@@ -60,6 +60,6 @@ describe 'yum::gpgkey' do
       }
     end
 
-    it { is_expected.to raise_error(Puppet::PreformattedError, %r{You cannot specify more than one of content, source}) }
+    it { is_expected.to compile.and_raise_error(%r{You cannot specify more than one of content, source}) }
   end
 end

--- a/spec/defines/versionlock_spec.rb
+++ b/spec/defines/versionlock_spec.rb
@@ -50,7 +50,7 @@ describe 'yum::versionlock' do
       context 'with version set namevar must be just a package name' do
         let(:params) { { version: '4.3' } }
 
-        it { is_expected.to raise_error(Puppet::PreformattedError, %r{Package name must be formatted as Yum::RpmName, not 'String'}) }
+        it { is_expected.to compile.and_raise_error(%r{Package name must be formatted as Yum::RpmName, not 'String'}) }
       end
     end
 
@@ -82,13 +82,13 @@ describe 'yum::versionlock' do
     context 'with an invalid title' do
       let(:title) { 'bash-4.1.2' }
 
-      it { is_expected.to raise_error(Puppet::PreformattedError, %r(%\{EPOCH\}:%\{NAME\}-%\{VERSION\}-%\{RELEASE\}\.%\{ARCH\})) }
+      it { is_expected.to compile.and_raise_error(%r(%\{EPOCH\}:%\{NAME\}-%\{VERSION\}-%\{RELEASE\}\.%\{ARCH\})) }
     end
 
     context 'with an invalid wildcard pattern' do
       let(:title) { '0:bash-4.1.2*' }
 
-      it { is_expected.to raise_error(Puppet::PreformattedError, %r(%\{EPOCH\}:%\{NAME\}-%\{VERSION\}-%\{RELEASE\}\.%\{ARCH\})) }
+      it { is_expected.to compile.and_raise_error(%r(%\{EPOCH\}:%\{NAME\}-%\{VERSION\}-%\{RELEASE\}\.%\{ARCH\})) }
     end
   end
 
@@ -135,7 +135,7 @@ describe 'yum::versionlock' do
     context 'with a simple, well-formed title, no version set' do
       let(:title) { 'bash' }
 
-      it { is_expected.to raise_error(Puppet::PreformattedError, %r{Version must be formatted as Yum::RpmVersion}) }
+      it { is_expected.to compile.and_raise_error(%r{Version must be formatted as Yum::RpmVersion}) }
 
       context 'and a version set to 4.3' do
         let(:params) { { version: '4.3' } }


### PR DESCRIPTION
#### Pull Request (PR) description

Rather than:

```ruby
 it { is_expected.to raise_error(Puppet::PreformattedError,
       `%r{Package name must be formatted as Yum::RpmName, not 'String'}
      )
 }
```

use

```ruby
it { is_expected.to compile.and_raise_error(
   %r{Package name must be formatted as Yum::RpmName, not 'String'}
)}
```