### PR TITLE
versionlock must specify at least .* for arch.

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -619,11 +619,11 @@ Default value: '*'
 
 ##### `arch`
 
-Data type: `Optional[Variant[Yum::RpmArch, Enum['*']]]`
+Data type: `Variant[Yum::RpmArch, Enum['*']]`
 
 Arch of the package if CentOS 8 mechanism is used.
 
-Default value: `undef`
+Default value: '*'
 
 ##### `epoch`
 

--- a/manifests/versionlock.pp
+++ b/manifests/versionlock.pp
@@ -58,7 +58,7 @@ define yum::versionlock (
   Optional[Yum::RpmVersion]                 $version = undef,
   Yum::RpmRelease                           $release = '*',
   Integer[0]                                $epoch   = 0,
-  Optional[Variant[Yum::RpmArch, Enum['*']]] $arch    = undef,
+  Variant[Yum::RpmArch, Enum['*']]          $arch    = '*',
 ) {
   require yum::plugin::versionlock
 
@@ -85,15 +85,9 @@ define yum::versionlock (
       fail("Version must be formatted as Yum::RpmVersion, not \'${actual}\'. See Yum::RpmVersion documentation for details.")
     }
 
-    if $arch {
-      $_dotarch = ".${arch}"
-    } else {
-      $_dotarch = ''
-    }
-
     $_versionlock = $facts['package_provider'] ? {
-      'yum'   => "${line_prefix}${epoch}:${name}-${version}-${release}${_dotarch}",
-      default => "${line_prefix}${name}-${epoch}:${version}-${release}${_dotarch}",
+      'yum'   => "${line_prefix}${epoch}:${name}-${version}-${release}.${arch}",
+      default => "${line_prefix}${name}-${epoch}:${version}-${release}.${arch}",
     }
 
   }

--- a/spec/defines/versionlock_spec.rb
+++ b/spec/defines/versionlock_spec.rb
@@ -105,7 +105,7 @@ describe 'yum::versionlock' do
       let(:params) { { version: '4.3' } }
 
       it 'contains a well-formed Concat::Fragment' do
-        is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("0:bash-4.3-*\n")
+        is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("0:bash-4.3-*.*\n")
       end
     end
 
@@ -141,7 +141,7 @@ describe 'yum::versionlock' do
         let(:params) { { version: '4.3' } }
 
         it 'contains a well-formed Concat::Fragment' do
-          is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-0:4.3-*\n")
+          is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-0:4.3-*.*\n")
         end
         context 'and an arch set to x86_64' do
           let(:params)  { super().merge(arch: 'x86_64') }
@@ -154,14 +154,14 @@ describe 'yum::versionlock' do
           let(:params) { super().merge(release: '22.5') }
 
           it 'contains a well-formed Concat::Fragment' do
-            is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-0:4.3-22.5\n")
+            is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-0:4.3-22.5.*\n")
           end
         end
         context 'and an epoch set to 5' do
           let(:params) { super().merge(epoch: 5) }
 
           it 'contains a well-formed Concat::Fragment' do
-            is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-5:4.3-*\n")
+            is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-5:4.3-*.*\n")
           end
         end
       end


### PR DESCRIPTION
#### Pull Request (PR) description
Previously it was possible to use an arch of `undef` which
produced versionlock files for both yum and dnf that would
never match a package.

Change the default to `*` so versionlock lines always end in
`.*` unless an arch is specified in which case it is
`.x86_64` for instance.
