### PR TITLE
De-duplicate start of string match character

### DIFF
--- a/types/rpmrelease.pp
+++ b/types/rpmrelease.pp
@@ -3,4 +3,4 @@
 # Output of `rpm -q --queryformat '%{release}\n' package`.
 # Examples 3.4 3.4.el6, 3.4.el6_2
 # @see http://ftp.rpm.org/max-rpm/ch-rpm-file-format.html
-type Yum::RpmRelease = Pattern[/\A^([^-]+)\z/]
+type Yum::RpmRelease = Pattern[/\A([^-]+)\z/]


### PR DESCRIPTION
#### Pull Request (PR) description
There were two start of string characters in a regex, `\A` and `^`. Reduce it to one which
is quite enough.
