### PR TITLE
Improve extraction of available updates

### DIFF
--- a/lib/facter/yum_updates.rb
+++ b/lib/facter/yum_updates.rb
@@ -6,14 +6,11 @@ Facter.add('yum_package_updates') do
     if File.executable?('/usr/bin/yum')
       yum_get_result = Facter::Util::Resolution.exec('/usr/bin/yum --assumeyes --quiet --cacheonly list updates')
       unless yum_get_result.nil?
-        first_line = true
         yum_get_result.each_line do |line|
-          if first_line
-            first_line = false
-            next
+          %r{\A(?<package>\S+\.\S+)\s+(?<available_version>[[:digit:]]\S+)\s+(?<repository>\S+)\s*\z} =~ line
+          if package && available_version && repository
+            yum_updates.push(package)
           end
-          package, _available_version, _repository = line.split(%r{\s+})
-          yum_updates.push(package)
         end
       end
     end

--- a/spec/unit/facter/yum_package_updates_spec.rb
+++ b/spec/unit/facter/yum_package_updates_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+describe 'yum_package_updates fact' do
+  subject { Facter.fact(:yum_package_updates).value }
+
+  after { Facter.clear }
+
+  describe 'on non-Redhat distro' do
+    before do
+      allow(Facter.fact(:osfamily)).to receive(:value).once.and_return('Debian')
+    end
+    it { is_expected.to be_nil }
+  end
+
+  describe 'on Redhat distro' do
+    before do
+      allow(Facter.fact(:osfamily)).to receive(:value).once.and_return('Redhat')
+      allow(File).to receive(:executable?) # Stub all other calls
+      allow(File).to receive(:executable?).with('/usr/bin/yum').and_return(true)
+      allow(Facter::Util::Resolution).to receive(:exec).with('/usr/bin/yum --assumeyes --quiet --cacheonly list updates').and_return(yum_list_updates_result)
+    end
+
+    context 'when no updates are available' do
+      let(:yum_list_updates_result) { '' }
+
+      it { is_expected.to eq([]) }
+    end
+
+    context 'when updates are available' do
+      let(:yum_list_updates_result) do
+        # rubocop:disable Layout/TrailingWhitespace
+        <<-END
+Updated Packages
+ca-certificates.noarch  2020.2.41-70.0.el7_8     updates           
+gitlab-ce.x86_64        13.1.1-ce.0.el7          gitlab_official_ce
+grafana.x86_64          7.0.4-1                  grafana-stable    
+kernel.x86_64           3.10.0-1127.13.1.el7     updates           
+kernel-headers.x86_64   3.10.0-1127.13.1.el7     updates           
+net-snmp-libs.x86_64    1:5.7.2-48.el7_8.1       updates           
+ntp.x86_64              4.2.6p5-29.el7.centos.2  updates           
+ntpdate.x86_64          4.2.6p5-29.el7.centos.2  updates           
+passenger.x86_64        6.0.5-1.el7              passenger         
+python-perf.x86_64      3.10.0-1127.13.1.el7     updates           
+unbound.x86_64          1.6.6-5.el7_8            updates           
+unbound-libs.x86_64     1.6.6-5.el7_8            updates           
+        END
+        # rubocop:enable Layout/TrailingWhitespace
+      end
+
+      it do
+        is_expected.to eq(%w[ca-certificates.noarch gitlab-ce.x86_64
+                             grafana.x86_64 kernel.x86_64 kernel-headers.x86_64
+                             net-snmp-libs.x86_64 ntp.x86_64 ntpdate.x86_64
+                             passenger.x86_64 python-perf.x86_64 unbound.x86_64
+                             unbound-libs.x86_64])
+      end
+    end
+
+    context 'when diagnostic messages are emitted' do
+      let(:yum_list_updates_result) do
+        <<-END
+https://oss-binaries.phusionpassenger.com/yum/passenger/el/7/x86_64/repodata/repomd.xml: [Errno -1] repomd.xml signature could not be verified for passenger
+Trying other mirror.
+Updated Packages
+ca-certificates.noarch  2020.2.41-70.0.el7_8     updates
+        END
+      end
+
+      it { is_expected.to eq(%w[ca-certificates.noarch]) }
+    end
+
+    context 'when plugins emit output' do
+      let(:yum_list_updates_result) do
+        <<-END
+Loaded plugins: auto-update-debuginfo, priorities, product-id, subscription-
+              : manager, versionlock
+ca-certificates.noarch  2020.2.41-70.0.el7_8     updates
+        END
+      end
+
+      it { is_expected.to eq(%w[ca-certificates.noarch]) }
+    end
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description

The `yum list updates` command outputs diagnostic messages and then the actual available updates both on stdout.  Depending on the installed yum plugins, a variable number of diagnostic lines are emitted, and the output is always formatted for humans, making it non-trivial to distinguish useless and relevant lines.

Instead of ignoring the first line, match each line with a pattern matching the following fields:
  - package: The name of the package for which an update is available, they are in the format `<package-name>.<architecture>`;
  - available_version: The version of the package available for update, ensure it starts with a digit;
  - repository: The repository containing the update

These fields are separated by a variable amount of space.  When a line match this pattern, consider the package as relevant for update.

#### This Pull Request (PR) fixes the following issues

Fixes #180 