### PR TITLE
yamllint failure on VirtuozzoLinux/7.yaml

### DIFF
--- a/data/os/RedHat/VirtuozzoLinux/7.yaml
+++ b/data/os/RedHat/VirtuozzoLinux/7.yaml
@@ -31,7 +31,6 @@ yum::repos:
     enabled: true
     gpgcheck: true
     priority: "90"
-    gpgkey:
     gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Virtuozzo-7"
     target: "/etc/yum.repos.d/virtuozzolinux-base.repo"
   virtuozzolinux-updates:


### PR DESCRIPTION
#### Pull Request (PR) description
yamllint failure on VirtuozzoLinux/7.yaml - duplication of key "gpgkey" in mapping (key-duplicates)

#### This Pull Request (PR) fixes the following issues
Fixes #189
