### PR TITLE
Fix plugin package name for DNF

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -23,9 +23,9 @@ define yum::plugin (
   if $pkg_prefix {
     $_pkg_prefix = $pkg_prefix
   } else {
-    $_pkg_prefix = $facts['os']['release']['major'] ? {
-      Variant[Integer[5,5], Enum['5']] => 'yum',
-      default                          => 'yum-plugin',
+    $_pkg_prefix = $facts['package_provider'] ? {
+      'dnf' => 'python3-dnf-plugin',
+      'yum' => 'yum-plugin',
     }
   }
 

--- a/spec/defines/plugin_spec.rb
+++ b/spec/defines/plugin_spec.rb
@@ -4,7 +4,6 @@ describe 'yum::plugin' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) { facts }
-      let(:prefix) { facts[:os]['release']['major'] == '5' ? 'yum' : 'yum-plugin' }
 
       context 'with no parameters' do
         let(:title) { 'fastestmirror' }


### PR DESCRIPTION
#### Pull Request (PR) description

DNF plugins (at least on CentOS 8) use different packages names than Yum plugins. Instead of yum-plugin-versionlock, you have python3-dnf-plugin-versionlock. 