### PR TITLE
fix package name for yum plugin versionlock on RHEL/CentOS 8

### DIFF
--- a/manifests/plugin/versionlock.pp
+++ b/manifests/plugin/versionlock.pp
@@ -18,8 +18,14 @@ class yum::plugin::versionlock (
   String                    $path   = '/etc/yum/pluginconf.d/versionlock.list',
   Boolean                   $clean  = false,
 ) {
+  $pkg_prefix = $facts['os']['release']['major'] ? {
+    Variant[Integer[5,5], Enum['5']] => 'yum',
+    '8' => 'python3-dnf-plugin',
+    default => 'yum-plugin',
+  }
   yum::plugin { 'versionlock':
-    ensure  => $ensure,
+    ensure     => $ensure,
+    pkg_prefix => $pkg_prefix,
   }
 
   include yum::clean

--- a/spec/acceptance/define_versionlock_spec.rb
+++ b/spec/acceptance/define_versionlock_spec.rb
@@ -43,7 +43,7 @@ describe 'yum::versionlock define' do
     end
     describe file('/etc/yum/pluginconf.d/versionlock.list') do
       it { is_expected.to be_file }
-      if %w[6 7].include?(fact('os.release.major'))
+      if %w[7].include?(fact('os.release.major'))
         it { is_expected.to contain '0:bash-4.1.2-9.el6_2.*' }
         it { is_expected.to contain '0:tcsh-3.1.2-9.el6_2.*' }
         it { is_expected.to contain '2:netscape-8.1.2-9.el6_2.*' }
@@ -51,6 +51,15 @@ describe 'yum::versionlock define' do
         it { is_expected.to contain 'bash-0:4.1.2-9.el6_2.*' }
         it { is_expected.to contain 'tcsh-0:3.1.2-9.el6_2.*' }
         it { is_expected.to contain 'netscape-2:8.1.2-9.el6_2.*' }
+      end
+    end
+    if fact('os.release.major') == '8'
+      describe package('python3-dnf-plugin-versionlock') do
+        it { is_expected.to be_installed }
+      end
+    else
+      describe package('yum-plugin-versionlock') do
+        it { is_expected.to be_installed }
       end
     end
   end
@@ -76,10 +85,11 @@ describe 'yum::versionlock define' do
     # Run it twice and test for idempotency
     apply_manifest(pp, catch_failures: true)
     apply_manifest(pp, catch_changes:  true)
+
     # Check the cache is really empty.
     # all repos will have 0 packages.
     # bit confused by the motivation of the first test?
-    if %w[6 7].include?(fact('os.release.major'))
+    if fact('os.release.major') == '7'
       shell('yum -C repolist -d0 | grep -v "repo id"  | awk "{print $NF}" FS=  | grep -v 0', acceptable_exit_codes: [1])
       shell('yum -q list available samba-devel', acceptable_exit_codes: [1])
     else


### PR DESCRIPTION
RHEL/CentOS 8 does not provide yum-plugin-versionlock, this patch sets the package prefix for the versionlock plugin package depending on the os release major version

fixes #197


