### PR TITLE
Add yum::copr resource to handle COPR repositories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,22 @@ yum::copr { 'copart/restic':
 }
 ```
 
+Please note that repositories added this way are not managed via `yumrepo` resources, but enabled and disabled via native package manager commands. As such, they would be purged by a declaration such as:
+
+```puppet
+resources { 'yumrepo':
+   purge => true,
+}
+```
+
+However, you can use modules such as [crayfishx-purge](https://forge.puppet.com/modules/crayfishx/purge) to exclude these resources from purging:
+
+```puppet
+purge { 'yumrepo':
+  unless => [ 'name', '=~', 'copr:.*' ],
+}
+```
+
 ### Manage a custom repo via Hiera data
 
 Using Hiera and automatic parameter lookup (APL), this module can manage

--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ yum::config { 'debuglevel':
 }
 ```
 
+### Manage COPR repositories
+
+This module also supports managing
+COPR ([Cool Other Package Repo](https://fedoraproject.org/wiki/Category:Copr))
+repositories via the `yum::copr` resource. The resource title specifies
+the COPR repository name, and `ensure` accepts the values `enabled`, `disabled`
+or `removed`. Example usage:
+
+```puppet
+yum::copr { 'copart/restic':
+  ensure => enabled,
+}
+```
+
 ### Manage a custom repo via Hiera data
 
 Using Hiera and automatic parameter lookup (APL), this module can manage

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -15,6 +15,7 @@
 ### Defined types
 
 * [`yum::config`](#yum--config): This definition manages yum.conf
+* [`yum::copr`](#yum--copr): This definition manages Copr (Cool Other Package Repo) repositories.
 * [`yum::gpgkey`](#yum--gpgkey): imports/deleted public GPG key for RPM. Key can be stored on Puppet's fileserver or as inline content.
 * [`yum::group`](#yum--group): This definition installs or removes yum package group.
 * [`yum::install`](#yum--install): Installs/removes rpms from local file/URL via yum install command.
@@ -382,6 +383,43 @@ Data type: `String`
 alternative conf. key (defaults to name)
 
 Default value: `$title`
+
+### <a name="yum--copr"></a>`yum::copr`
+
+This definition manages Copr (Cool Other Package Repo) repositories.
+
+#### Examples
+
+##### add and enable COPR restic repository
+
+```puppet
+yum::copr { 'copart/restic':
+  ensure  => 'enabled',
+}
+```
+
+#### Parameters
+
+The following parameters are available in the `yum::copr` defined type:
+
+* [`copr_repo`](#-yum--copr--copr_repo)
+* [`ensure`](#-yum--copr--ensure)
+
+##### <a name="-yum--copr--copr_repo"></a>`copr_repo`
+
+Data type: `String`
+
+name of repository, defaults to title
+
+Default value: `$title`
+
+##### <a name="-yum--copr--ensure"></a>`ensure`
+
+Data type: `Enum['enabled', 'disabled', 'removed']`
+
+specifies if repo should be enabled, disabled or removed
+
+Default value: `'enabled'`
 
 ### <a name="yum--gpgkey"></a>`yum::gpgkey`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -403,21 +403,30 @@ yum::copr { 'copart/restic':
 The following parameters are available in the `yum::copr` defined type:
 
 * [`copr_repo`](#-yum--copr--copr_repo)
+* [`manage_prereq_plugin`](#-yum--copr--manage_prereq_plugin)
 * [`ensure`](#-yum--copr--ensure)
 
 ##### <a name="-yum--copr--copr_repo"></a>`copr_repo`
 
 Data type: `String`
 
-name of repository, defaults to title
+Name of repository, defaults to title.
 
 Default value: `$title`
+
+##### <a name="-yum--copr--manage_prereq_plugin"></a>`manage_prereq_plugin`
+
+Data type: `Boolean`
+
+Wheter required plugin for dnf/yum should be installed by this resource.
+
+Default value: `true`
 
 ##### <a name="-yum--copr--ensure"></a>`ensure`
 
 Data type: `Enum['enabled', 'disabled', 'removed']`
 
-specifies if repo should be enabled, disabled or removed
+Specifies if repo should be enabled, disabled or removed.
 
 Default value: `'enabled'`
 

--- a/manifests/copr.pp
+++ b/manifests/copr.pp
@@ -1,18 +1,10 @@
-# Define: yum::copr
 #
-# This definition manages Copr (Cool Other Package Repo) repositories.
+# @summary This definition manages Copr (Cool Other Package Repo) repositories.
 #
-# Parameters:
-#   [*copr_repo*] - name of repository, defaults to title
-#   [*ensure*]    - specifies if repo should be enabled,
-#                   disabled or removed
+# @param copr_repo name of repository, defaults to title
+# @param ensure specifies if repo should be enabled, disabled or removed
 #
-# Actions:
-#
-# Requires:
-#   RPM based system
-#
-# Sample usage:
+# @example add and enable COPR restic repository
 #   yum::copr { 'copart/restic':
 #     ensure  => 'enabled',
 #   }

--- a/manifests/copr.pp
+++ b/manifests/copr.pp
@@ -1,0 +1,79 @@
+# Define: yum::copr
+#
+# This definition manages Copr (Cool Other Package Repo) repositories.
+#
+# Parameters:
+#   [*copr_repo*] - name of repository, defaults to title
+#   [*ensure*]    - specifies if repo should be enabled,
+#                   disabled or removed
+#
+# Actions:
+#
+# Requires:
+#   RPM based system
+#
+# Sample usage:
+#   yum::copr { 'copart/restic':
+#     ensure  => 'enabled',
+#   }
+#
+define yum::copr (
+  String                                 $copr_repo = $title,
+  Enum['enabled', 'disabled', 'removed'] $ensure    = 'enabled',
+) {
+  $prereq_plugin = $facts['package_provider'] ? {
+    'dnf'   => 'dnf-plugins-core',
+    default => 'yum-plugin-copr',
+  }
+  stdlib::ensure_packages([$prereq_plugin])
+
+  if $facts['package_provider'] == 'dnf' {
+    case $ensure {
+      'enabled': {
+        exec { "dnf -y copr enable ${copr_repo}":
+          path    => '/bin:/usr/bin:/sbin/:/usr/sbin',
+          unless  => "dnf copr list | egrep -q '${copr_repo}\$'",
+          require => Package[$prereq_plugin],
+        }
+      }
+      'disabled': {
+        exec { "dnf -y copr disable ${copr_repo}":
+          path    => '/bin:/usr/bin:/sbin/:/usr/sbin',
+          unless  => "dnf copr list | egrep -q '${copr_repo} (disabled)\$'",
+          require => Package[$prereq_plugin],
+        }
+      }
+      'removed': {
+        exec { "dnf -y copr remove ${copr_repo}":
+          path    => '/bin:/usr/bin:/sbin/:/usr/sbin',
+          onlyif  => "dnf copr list | egrep -q '${copr_repo}'",
+          require => Package[$prereq_plugin],
+        }
+      }
+      default: {
+        fail("The value for ensure for `yum::copr` must be enabled, disabled or removed, but it is ${ensure}.")
+      }
+    }
+  } else {
+    $copr_repo_name_part = regsubst($copr_repo, '/', '-', 'G')
+    case $ensure {
+      'enabled': {
+        exec { "yum -y copr enable ${copr_repo}":
+          path    => '/bin:/usr/bin:/sbin/:/usr/sbin',
+          onlyif  => "test ! -e /etc/yum.repos.d/_copr_${copr_repo_name_part}.repo",
+          require => Package[$prereq_plugin],
+        }
+      }
+      'disabled', 'removed': {
+        exec { "yum -y copr disable ${copr_repo}":
+          path    => '/bin:/usr/bin:/sbin/:/usr/sbin',
+          onlyif  => "test -e /etc/yum.repos.d/_copr_${copr_repo_name_part}.repo",
+          require => Package[$prereq_plugin],
+        }
+      }
+      default: {
+        fail("The value for ensure for `yum::copr` must be enabled, disabled or removed, but it is ${ensure}.")
+      }
+    }
+  }
+}

--- a/manifests/copr.pp
+++ b/manifests/copr.pp
@@ -1,8 +1,12 @@
 #
 # @summary This definition manages Copr (Cool Other Package Repo) repositories.
 #
-# @param copr_repo name of repository, defaults to title
-# @param ensure specifies if repo should be enabled, disabled or removed
+# @param copr_repo
+#   Name of repository, defaults to title.
+# @param manage_prereq_plugin
+#   Wheter required plugin for dnf/yum should be installed by this resource.
+# @param ensure
+#   Specifies if repo should be enabled, disabled or removed.
 #
 # @example add and enable COPR restic repository
 #   yum::copr { 'copart/restic':
@@ -10,14 +14,17 @@
 #   }
 #
 define yum::copr (
-  String                                 $copr_repo = $title,
-  Enum['enabled', 'disabled', 'removed'] $ensure    = 'enabled',
+  String                                 $copr_repo            = $title,
+  Boolean                                $manage_prereq_plugin = true,
+  Enum['enabled', 'disabled', 'removed'] $ensure               = 'enabled',
 ) {
   $prereq_plugin = $facts['package_provider'] ? {
     'dnf'   => 'dnf-plugins-core',
     default => 'yum-plugin-copr',
   }
-  stdlib::ensure_packages([$prereq_plugin])
+  if $manage_prereq_plugin {
+    stdlib::ensure_packages([$prereq_plugin])
+  }
 
   if $facts['package_provider'] == 'dnf' {
     case $ensure {

--- a/spec/defines/copr_spec.rb
+++ b/spec/defines/copr_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'yum::copr' do
+  context 'with package_provider set to yum' do
+    let(:facts) { { package_provider: 'yum' } }
+    let(:prereq_plugin) { 'yum-plugin-copr' }
+    let(:title) { 'copart/restic' }
+    let(:copr_repo_name_part) { title.gsub('/', '-') }
+
+    context 'package provider plugin installed' do
+      it { is_expected.to compile.with_all_deps }
+
+      it {
+        is_expected.to contain_package(prereq_plugin.to_s)
+      }
+    end
+
+    context 'with ensure = enabled' do
+      let(:params) { { ensure: 'enabled' } }
+
+      it { is_expected.to compile.with_all_deps }
+
+      it {
+        is_expected.to contain_exec("yum -y copr enable #{title}").with(
+          'path'    => '/bin:/usr/bin:/sbin/:/usr/sbin',
+          'onlyif'  => "test ! -e /etc/yum.repos.d/_copr_#{copr_repo_name_part}.repo",
+          'require' => "Package[#{prereq_plugin}]"
+        )
+      }
+    end
+
+    context 'with ensure = disabled' do
+      let(:params) { { ensure: 'disabled' } }
+
+      it { is_expected.to compile.with_all_deps }
+
+      it {
+        is_expected.to contain_exec("yum -y copr disable #{title}").with(
+          'path'    => '/bin:/usr/bin:/sbin/:/usr/sbin',
+          'onlyif'  => "test -e /etc/yum.repos.d/_copr_#{copr_repo_name_part}.repo",
+          'require' => "Package[#{prereq_plugin}]"
+        )
+      }
+    end
+
+    context 'with ensure = removed' do
+      let(:params) { { ensure: 'removed' } }
+
+      it { is_expected.to compile.with_all_deps }
+
+      it {
+        is_expected.to contain_exec("yum -y copr disable #{title}").with(
+          'path'    => '/bin:/usr/bin:/sbin/:/usr/sbin',
+          'onlyif'  => "test -e /etc/yum.repos.d/_copr_#{copr_repo_name_part}.repo",
+          'require' => "Package[#{prereq_plugin}]"
+        )
+      }
+    end
+  end
+
+  context 'with package_provider set to dnf' do
+    let(:facts) { { package_provider: 'dnf' } }
+    let(:prereq_plugin) { 'dnf-plugins-core' }
+    let(:title) { 'copart/restic' }
+
+    context 'package provider plugin installed' do
+      it { is_expected.to compile.with_all_deps }
+
+      it {
+        is_expected.to contain_package(prereq_plugin.to_s)
+      }
+    end
+
+    context 'with ensure = enabled' do
+      let(:params) { { ensure: 'enabled' } }
+
+      it { is_expected.to compile.with_all_deps }
+
+      it {
+        is_expected.to contain_exec("dnf -y copr enable #{title}").with(
+          'path'    => '/bin:/usr/bin:/sbin/:/usr/sbin',
+          'unless'  => "dnf copr list | egrep -q '#{title}\$'",
+          'require' => "Package[#{prereq_plugin}]"
+        )
+      }
+    end
+
+    context 'with ensure = disabled' do
+      let(:params) { { ensure: 'disabled' } }
+
+      it { is_expected.to compile.with_all_deps }
+
+      it {
+        is_expected.to contain_exec("dnf -y copr disable #{title}").with(
+          'path'    => '/bin:/usr/bin:/sbin/:/usr/sbin',
+          'unless'  => "dnf copr list | egrep -q '#{title} (disabled)\$'",
+          'require' => "Package[#{prereq_plugin}]"
+        )
+      }
+    end
+
+    context 'with ensure = removed' do
+      let(:params) { { ensure: 'removed' } }
+
+      it { is_expected.to compile.with_all_deps }
+
+      it {
+        is_expected.to contain_exec("dnf -y copr remove #{title}").with(
+          'path'    => '/bin:/usr/bin:/sbin/:/usr/sbin',
+          'onlyif'  => "dnf copr list | egrep -q '#{title}'",
+          'require' => "Package[#{prereq_plugin}]"
+        )
+      }
+    end
+  end
+end


### PR DESCRIPTION
COPR (Cool Other Package Repo) is a Fedora project for third-party package repositories, see:
https://copr.fedorainfracloud.org/

#### Pull Request (PR) description
This PR adds support to manage COPR repositories via a new `yum::copr` resource. 
Documentation and test are included. 

#### This Pull Request (PR) fixes the following issues
Fixes #149
