### PR TITLE
New type yum::post_transaction_action

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,16 @@ yum::versionlock{'bash':
 }
 ```
 
+### Run a post transaction command
+Specify a command to run after transactions of packages.
+
+```puppet
+yum::post_transaction_action{'touch_file':
+  key     => 'openssh-*',
+  command => 'touch /tmp/openssh-package-updated',
+}
+```
+
 ### Install or remove *yum* package group
 
 Install yum [package groups][3].  To list groups: `yum group list`. Then use

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -8,6 +8,7 @@
 
 * [`yum`](#yum): A class to install and manage Yum configuration.
 * [`yum::clean`](#yumclean): A $(yum clean all) Exec to be notified if desired.
+* [`yum::plugin::post_transaction_actions`](#yumpluginpost_transaction_actions): Class to install post_transaction plugin
 * [`yum::plugin::versionlock`](#yumpluginversionlock): Class: yum::plugin::versionlock  This class installs versionlock plugin  Parameters:   [*ensure*] - specifies if versionlock should be presen
 
 ### Defined types
@@ -17,6 +18,7 @@
 * [`yum::group`](#yumgroup): Define: yum::group  This definition installs or removes yum package group.  Parameters:   [*ensure*]   - specifies if package group should be
 * [`yum::install`](#yuminstall): Define: yum::install  This definition installs or removes rpms from local file or URL via yum install command. This can be better than using 
 * [`yum::plugin`](#yumplugin): Define: yum::plugin  This definition installs Yum plugin.  Parameters:   [*ensure*]   - specifies if plugin should be present or absent  Acti
+* [`yum::post_transaction_action`](#yumpost_transaction_action): Creates post transaction configuratons for dnf or yum.
 * [`yum::versionlock`](#yumversionlock): Locks package from updates.
 
 ### Functions
@@ -27,6 +29,7 @@
 
 * [`Yum::RpmArch`](#yumrpmarch): Valid rpm architectures.
 * [`Yum::RpmName`](#yumrpmname): Valid rpm name.
+* [`Yum::RpmNameGlob`](#yumrpmnameglob): Valid rpm name with globs.
 * [`Yum::RpmRelease`](#yumrpmrelease): Valid rpm release fields.
 * [`Yum::RpmVersion`](#yumrpmversion): Valid rpm version fields.
 * [`Yum::VersionlockString`](#yumversionlockstring): This type matches strings appropriate for use with yum-versionlock. Its basic format, using the `rpm(8)` query string format, is `%{EPOCH}:%{
@@ -37,7 +40,7 @@
 
 ## Classes
 
-### `yum`
+### <a name="yum"></a>`yum`
 
 A class to install and manage Yum configuration.
 
@@ -99,9 +102,20 @@ yum::repos:
 
 #### Parameters
 
-The following parameters are available in the `yum` class.
+The following parameters are available in the `yum` class:
 
-##### `clean_old_kernels`
+* [`clean_old_kernels`](#clean_old_kernels)
+* [`keep_kernel_devel`](#keep_kernel_devel)
+* [`config_options`](#config_options)
+* [`repos`](#repos)
+* [`managed_repos`](#managed_repos)
+* [`manage_os_default_repos`](#manage_os_default_repos)
+* [`os_default_repos`](#os_default_repos)
+* [`repo_exclusions`](#repo_exclusions)
+* [`gpgkeys`](#gpgkeys)
+* [`utils_package_name`](#utils_package_name)
+
+##### <a name="clean_old_kernels"></a>`clean_old_kernels`
 
 Data type: `Boolean`
 
@@ -109,7 +123,7 @@ Whether or not to purge old kernel version beyond the `keeponly_limit`.
 
 Default value: ``true``
 
-##### `keep_kernel_devel`
+##### <a name="keep_kernel_devel"></a>`keep_kernel_devel`
 
 Data type: `Boolean`
 
@@ -117,7 +131,7 @@ Whether or not to keep kernel devel packages on old kernel purge.
 
 Default value: ``false``
 
-##### `config_options`
+##### <a name="config_options"></a>`config_options`
 
 Data type: `Hash[String, Variant[String, Integer, Boolean, Hash[String, Variant[String, Integer, Boolean]]]]`
 
@@ -127,9 +141,9 @@ are either the direct `ensure` value, or a Hash of the resource's attributes.
 @note Boolean parameter values will be converted to either a `1` or `0`; use a quoted string to
   get a literal `true` or `false`.
 
-Default value: `{ }`
+Default value: `{}`
 
-##### `repos`
+##### <a name="repos"></a>`repos`
 
 Data type: `Optional[Hash[String, Optional[Hash[String, Variant[String, Integer, Boolean]]]]]`
 
@@ -144,7 +158,7 @@ parameters may be overriden or removed via global or environment Hiera data.
 
 Default value: `{}`
 
-##### `managed_repos`
+##### <a name="managed_repos"></a>`managed_repos`
 
 Data type: `Array[String]`
 
@@ -157,7 +171,7 @@ set in the module's Hiera data.
 
 Default value: `[]`
 
-##### `manage_os_default_repos`
+##### <a name="manage_os_default_repos"></a>`manage_os_default_repos`
 
 Data type: `Boolean`
 
@@ -168,7 +182,7 @@ Whether or not to add an operating system's default repos to the `managed_repos`
 
 Default value: ``false``
 
-##### `os_default_repos`
+##### <a name="os_default_repos"></a>`os_default_repos`
 
 Data type: `Array[String]`
 
@@ -177,7 +191,7 @@ Normally this should not be modified.
 
 Default value: `[]`
 
-##### `repo_exclusions`
+##### <a name="repo_exclusions"></a>`repo_exclusions`
 
 Data type: `Array[String]`
 
@@ -187,7 +201,7 @@ instantiation.
 
 Default value: `[]`
 
-##### `gpgkeys`
+##### <a name="gpgkeys"></a>`gpgkeys`
 
 Data type: `Hash[String, Hash[String, String]]`
 
@@ -197,7 +211,7 @@ as repos.
 
 Default value: `{}`
 
-##### `utils_package_name`
+##### <a name="utils_package_name"></a>`utils_package_name`
 
 Data type: `String`
 
@@ -205,11 +219,43 @@ Name of the utils package, e.g. 'yum-utils', or 'dnf-utils'.
 
 Default value: `'yum-utils'`
 
-### `yum::clean`
+### <a name="yumclean"></a>`yum::clean`
 
 A $(yum clean all) Exec to be notified if desired.
 
-### `yum::plugin::versionlock`
+### <a name="yumpluginpost_transaction_actions"></a>`yum::plugin::post_transaction_actions`
+
+class{'yum::plugin::post_transaction_actions':
+  ensure => present,
+}
+
+* **See also**
+  * https://dnf-plugins-core.readthedocs.io/en/latest/post-transaction-actions.html
+    * DNF Post Transaction Items
+
+#### Examples
+
+##### Enable post_transaction_action plugin
+
+```puppet
+
+```
+
+#### Parameters
+
+The following parameters are available in the `yum::plugin::post_transaction_actions` class:
+
+* [`ensure`](#ensure)
+
+##### <a name="ensure"></a>`ensure`
+
+Data type: `Enum['present', 'absent']`
+
+Should the post_transaction actions plugin be installed
+
+Default value: `'present'`
+
+### <a name="yumpluginversionlock"></a>`yum::plugin::versionlock`
 
 Class: yum::plugin::versionlock
 
@@ -228,9 +274,13 @@ Sample usage:
 
 #### Parameters
 
-The following parameters are available in the `yum::plugin::versionlock` class.
+The following parameters are available in the `yum::plugin::versionlock` class:
 
-##### `ensure`
+* [`ensure`](#ensure)
+* [`path`](#path)
+* [`clean`](#clean)
+
+##### <a name="ensure"></a>`ensure`
 
 Data type: `Enum['present', 'absent']`
 
@@ -238,7 +288,7 @@ Data type: `Enum['present', 'absent']`
 
 Default value: `'present'`
 
-##### `path`
+##### <a name="path"></a>`path`
 
 Data type: `String`
 
@@ -246,7 +296,7 @@ Data type: `String`
 
 Default value: `'/etc/yum/pluginconf.d/versionlock.list'`
 
-##### `clean`
+##### <a name="clean"></a>`clean`
 
 Data type: `Boolean`
 
@@ -256,7 +306,7 @@ Default value: ``false``
 
 ## Defined types
 
-### `yum::config`
+### <a name="yumconfig"></a>`yum::config`
 
 Define: yum::config
 
@@ -283,15 +333,18 @@ Sample usage:
 
 #### Parameters
 
-The following parameters are available in the `yum::config` defined type.
+The following parameters are available in the `yum::config` defined type:
 
-##### `ensure`
+* [`ensure`](#ensure)
+* [`key`](#key)
+
+##### <a name="ensure"></a>`ensure`
 
 Data type: `Variant[Boolean, Integer, Enum['absent'], String]`
 
 
 
-##### `key`
+##### <a name="key"></a>`key`
 
 Data type: `String`
 
@@ -299,7 +352,7 @@ Data type: `String`
 
 Default value: `$title`
 
-### `yum::gpgkey`
+### <a name="yumgpgkey"></a>`yum::gpgkey`
 
 Define: yum::gpgkey
 
@@ -331,9 +384,17 @@ Sample usage:
 
 #### Parameters
 
-The following parameters are available in the `yum::gpgkey` defined type.
+The following parameters are available in the `yum::gpgkey` defined type:
 
-##### `path`
+* [`path`](#path)
+* [`ensure`](#ensure)
+* [`content`](#content)
+* [`source`](#source)
+* [`owner`](#owner)
+* [`group`](#group)
+* [`mode`](#mode)
+
+##### <a name="path"></a>`path`
 
 Data type: `String`
 
@@ -341,7 +402,7 @@ Data type: `String`
 
 Default value: `$name`
 
-##### `ensure`
+##### <a name="ensure"></a>`ensure`
 
 Data type: `Enum['present', 'absent']`
 
@@ -349,7 +410,7 @@ Data type: `Enum['present', 'absent']`
 
 Default value: `'present'`
 
-##### `content`
+##### <a name="content"></a>`content`
 
 Data type: `Optional[String]`
 
@@ -357,7 +418,7 @@ Data type: `Optional[String]`
 
 Default value: ``undef``
 
-##### `source`
+##### <a name="source"></a>`source`
 
 Data type: `Optional[String]`
 
@@ -365,7 +426,7 @@ Data type: `Optional[String]`
 
 Default value: ``undef``
 
-##### `owner`
+##### <a name="owner"></a>`owner`
 
 Data type: `String`
 
@@ -373,7 +434,7 @@ Data type: `String`
 
 Default value: `'root'`
 
-##### `group`
+##### <a name="group"></a>`group`
 
 Data type: `String`
 
@@ -381,7 +442,7 @@ Data type: `String`
 
 Default value: `'root'`
 
-##### `mode`
+##### <a name="mode"></a>`mode`
 
 Data type: `String`
 
@@ -389,7 +450,7 @@ Data type: `String`
 
 Default value: `'0644'`
 
-### `yum::group`
+### <a name="yumgroup"></a>`yum::group`
 
 Define: yum::group
 
@@ -413,9 +474,13 @@ Sample usage:
 
 #### Parameters
 
-The following parameters are available in the `yum::group` defined type.
+The following parameters are available in the `yum::group` defined type:
 
-##### `install_options`
+* [`install_options`](#install_options)
+* [`ensure`](#ensure)
+* [`timeout`](#timeout)
+
+##### <a name="install_options"></a>`install_options`
 
 Data type: `Array[String[1]]`
 
@@ -423,7 +488,7 @@ Data type: `Array[String[1]]`
 
 Default value: `[]`
 
-##### `ensure`
+##### <a name="ensure"></a>`ensure`
 
 Data type: `Enum['present', 'installed', 'latest', 'absent', 'purged']`
 
@@ -431,7 +496,7 @@ Data type: `Enum['present', 'installed', 'latest', 'absent', 'purged']`
 
 Default value: `'present'`
 
-##### `timeout`
+##### <a name="timeout"></a>`timeout`
 
 Data type: `Optional[Integer]`
 
@@ -439,7 +504,7 @@ Data type: `Optional[Integer]`
 
 Default value: ``undef``
 
-### `yum::install`
+### <a name="yuminstall"></a>`yum::install`
 
 Define: yum::install
 
@@ -465,15 +530,19 @@ Sample usage:
 
 #### Parameters
 
-The following parameters are available in the `yum::install` defined type.
+The following parameters are available in the `yum::install` defined type:
 
-##### `source`
+* [`source`](#source)
+* [`ensure`](#ensure)
+* [`timeout`](#timeout)
+
+##### <a name="source"></a>`source`
 
 Data type: `String`
 
 
 
-##### `ensure`
+##### <a name="ensure"></a>`ensure`
 
 Data type: `Enum['present', 'installed', 'absent', 'purged']`
 
@@ -481,7 +550,7 @@ Data type: `Enum['present', 'installed', 'absent', 'purged']`
 
 Default value: `'present'`
 
-##### `timeout`
+##### <a name="timeout"></a>`timeout`
 
 Data type: `Optional[Integer]`
 
@@ -489,7 +558,7 @@ Data type: `Optional[Integer]`
 
 Default value: ``undef``
 
-### `yum::plugin`
+### <a name="yumplugin"></a>`yum::plugin`
 
 Define: yum::plugin
 
@@ -510,9 +579,13 @@ Sample usage:
 
 #### Parameters
 
-The following parameters are available in the `yum::plugin` defined type.
+The following parameters are available in the `yum::plugin` defined type:
 
-##### `ensure`
+* [`ensure`](#ensure)
+* [`pkg_prefix`](#pkg_prefix)
+* [`pkg_name`](#pkg_name)
+
+##### <a name="ensure"></a>`ensure`
 
 Data type: `Enum['present', 'absent']`
 
@@ -520,7 +593,7 @@ Data type: `Enum['present', 'absent']`
 
 Default value: `'present'`
 
-##### `pkg_prefix`
+##### <a name="pkg_prefix"></a>`pkg_prefix`
 
 Data type: `Optional[String]`
 
@@ -528,7 +601,7 @@ Data type: `Optional[String]`
 
 Default value: ``undef``
 
-##### `pkg_name`
+##### <a name="pkg_name"></a>`pkg_name`
 
 Data type: `Optional[String]`
 
@@ -536,7 +609,72 @@ Data type: `Optional[String]`
 
 Default value: ``undef``
 
-### `yum::versionlock`
+### <a name="yumpost_transaction_action"></a>`yum::post_transaction_action`
+
+yum::post_transaction_action{'touch file on ssh package update':
+  key     => 'openssh-*',
+  state   => 'any',
+  command => 'touch /tmp/openssh-installed',
+}
+
+* **See also**
+  * https://dnf-plugins-core.readthedocs.io/en/latest/post-transaction-actions.html
+    * DNF Post Transaction Items
+
+#### Examples
+
+##### Touch a file when ssh is package is updated, installed or removed.
+
+```puppet
+
+```
+
+#### Parameters
+
+The following parameters are available in the `yum::post_transaction_action` defined type:
+
+* [`action`](#action)
+* [`key`](#key)
+* [`state`](#state)
+* [`action`](#action)
+* [`command`](#command)
+
+##### <a name="action"></a>`action`
+
+Data type: `String[1]`
+
+Name variable a string to label the rule
+
+Default value: `$title`
+
+##### <a name="key"></a>`key`
+
+Data type: `Variant[Enum['*'],Yum::RpmNameGlob,Stdlib::Unixpath]`
+
+Package name, glob or file name file glob.
+
+##### <a name="state"></a>`state`
+
+Data type: `Enum['install', 'update', 'remove', 'any', 'in', 'out']`
+
+Can be `install`, `update`, `remove` or `any` on YUM based systems.
+Can be `in`, `out` or `any` on DNF based systems.
+
+Default value: `'any'`
+
+##### <a name="action"></a>`action`
+
+The command to run
+
+Default value: `$title`
+
+##### <a name="command"></a>`command`
+
+Data type: `String[1]`
+
+
+
+### <a name="yumversionlock"></a>`yum::versionlock`
 
 Locks package from updates.
 
@@ -591,9 +729,15 @@ yum::versionlock { 'bash':
 
 #### Parameters
 
-The following parameters are available in the `yum::versionlock` defined type.
+The following parameters are available in the `yum::versionlock` defined type:
 
-##### `ensure`
+* [`ensure`](#ensure)
+* [`version`](#version)
+* [`release`](#release)
+* [`arch`](#arch)
+* [`epoch`](#epoch)
+
+##### <a name="ensure"></a>`ensure`
 
 Data type: `Enum['present', 'absent', 'exclude']`
 
@@ -601,7 +745,7 @@ Specifies if versionlock should be `present`, `absent` or `exclude`.
 
 Default value: `'present'`
 
-##### `version`
+##### <a name="version"></a>`version`
 
 Data type: `Optional[Yum::RpmVersion]`
 
@@ -610,7 +754,7 @@ If version is set then the name var is assumed to a package name and not the ful
 
 Default value: ``undef``
 
-##### `release`
+##### <a name="release"></a>`release`
 
 Data type: `Yum::RpmRelease`
 
@@ -618,7 +762,7 @@ Release of the package if CentOS 8 mechanism is used.
 
 Default value: `'*'`
 
-##### `arch`
+##### <a name="arch"></a>`arch`
 
 Data type: `Variant[Yum::RpmArch, Enum['*']]`
 
@@ -626,7 +770,7 @@ Arch of the package if CentOS 8 mechanism is used.
 
 Default value: `'*'`
 
-##### `epoch`
+##### <a name="epoch"></a>`epoch`
 
 Data type: `Integer[0]`
 
@@ -636,7 +780,7 @@ Default value: `0`
 
 ## Functions
 
-### `yum::bool2num_hash_recursive`
+### <a name="yumbool2num_hash_recursive"></a>`yum::bool2num_hash_recursive`
 
 Type: Puppet Language
 
@@ -708,24 +852,43 @@ The hash on which to operate
 
 ## Data types
 
-### `Yum::RpmArch`
+### <a name="yumrpmarch"></a>`Yum::RpmArch`
 
 Output of `rpm -q --queryformat '%{arch}\n' package`
 
 * **See also**
   * https://github.com/rpm-software-management/rpm/blob/master/rpmrc.in
 
-Alias of `Enum['noarch', 'x86_64', 'i386', 'arm', 'ppc64', 'ppc64le', 'sparc64', 'ia64', 'alpha', 'ip', 'm68k', 'mips', 'mipsel', 'mk68k', 'mint', 'ppc', 'rs6000', 's390', 's390x', 'sh', 'sparc', 'xtensa']`
+Alias of
 
-### `Yum::RpmName`
+```puppet
+Enum['noarch', 'x86_64', 'i386', 'arm', 'ppc64', 'ppc64le', 'sparc64', 'ia64', 'alpha', 'ip', 'm68k', 'mips', 'mipsel', 'mk68k', 'mint', 'ppc', 'rs6000', 's390', 's390x', 'sh', 'sparc', 'xtensa']
+```
+
+### <a name="yumrpmname"></a>`Yum::RpmName`
 
 Can be alphanumeric or contain `.` `_` `+` `%` `{` `}` `-`.
 Output of `rpm -q --queryformat '%{name}\n package`
 Examples python36-foobar, netscape
 
-Alias of `Pattern[/\A([0-9a-zA-Z\._\+%\{\}-]+)\z/]`
+Alias of
 
-### `Yum::RpmRelease`
+```puppet
+Pattern[/\A([0-9a-zA-Z\._\+%\{\}-]+)\z/]
+```
+
+### <a name="yumrpmnameglob"></a>`Yum::RpmNameGlob`
+
+Can be alphanumeric or contain `.` `_` `+` `%` `{` `}` `-` `*`.
+Examples python36-*, *netscape
+
+Alias of
+
+```puppet
+Pattern[/\A([*0-9a-zA-Z\._\+%\{\}-]+)\z/]
+```
+
+### <a name="yumrpmrelease"></a>`Yum::RpmRelease`
 
 It may not contain a dash.
 Output of `rpm -q --queryformat '%{release}\n' package`.
@@ -734,9 +897,13 @@ Examples 3.4 3.4.el6, 3.4.el6_2
 * **See also**
   * http://ftp.rpm.org/max-rpm/ch-rpm-file-format.html
 
-Alias of `Pattern[/\A([^-]+)\z/]`
+Alias of
 
-### `Yum::RpmVersion`
+```puppet
+Pattern[/\A([^-]+)\z/]
+```
+
+### <a name="yumrpmversion"></a>`Yum::RpmVersion`
 
 It may not contain a dash.
 Output of `rpm -q --queryformat '%{version}\n' package`.
@@ -745,9 +912,13 @@ Examples 3.4, 2.5.alpha6
 * **See also**
   * http://ftp.rpm.org/max-rpm/ch-rpm-file-format.html
 
-Alias of `Pattern[/\A([^-]+)\z/]`
+Alias of
 
-### `Yum::VersionlockString`
+```puppet
+Pattern[/\A([^-]+)\z/]
+```
+
+### <a name="yumversionlockstring"></a>`Yum::VersionlockString`
 
 This type matches strings appropriate for use with yum-versionlock.
 Its basic format, using the `rpm(8)` query string format, is
@@ -766,8 +937,10 @@ breaks down into five distinct parts, plus the seperators.
   RELEASE: Any valid release string. Only limitation is that it is not a dash (`-`)
   type Yum::PackageRelease = Regexp[/[^-]+/]
 
+lint:ignore:140chars
   ARCH: Matches a string such as `el7.x86_64`.  This is actuall two sub-expressions.  See below.
   type Yum::PackageArch    = Regexp[/([0-9a-zZ-Z_\*]+)(?:\.(noarch|x86_64|i386|arm|ppc64|ppc64le|sparc64|ia64|alpha|ip|m68k|mips|mipsel|mk68k|mint|ppc|rs6000|s390|s390x|sh|sparc|xtensa|\*))?/]
+lint:endignore
 
 The `%{ARCH}` sub-expression is composed of two sub-expressions
 separated by a dot (`.`), where the second part is optional.  The RPM
@@ -777,12 +950,16 @@ specification calls the first field the `DistTag`, and the second the
    DistTag: Any string consiting of only letters, numbers, or an underscore, e.g., `el6`, `sl7`, or `fc24`.
    type Yum::PackageDistTag   = Regexp[/[0-9a-zZ-Z_\*]+/]
 
+lint:ignore:140chars
    BuildArch: Any string from the list at https://github.com/rpm-software-management/rpm/blob/master/rpmrc.in.  Strings are roughly listed from most common to least common to improve performance.
    type Yum::PackageBuildArch = Regexp[/noarch|x86_64|i386|arm|ppc64|ppc64le|sparc64|ia64|alpha|ip|m68k|mips|mipsel|mk68k|mint|ppc|rs6000|s390|s390x|sh|sparc|xtensa/]
+lint:endignore
 
 wildcard characters may not span the fields, may not cover the
 seperators.  This is an undocumented but tested limitation of
 yum-versionlock.
+
+lint:ignore:140chars
 
 * **Note** Each field may contain wildcard characters (`*`), but the
 
@@ -818,11 +995,15 @@ yum-versionlock.
 
 ```
 
-Alias of `Pattern[/^([0-9\*]+):([0-9a-zA-Z\._\+%\{\}\*-]+)-([^-]+)-([^-]+)\.(([0-9a-zZ-Z_\*]+)(?:\.(noarch|x86_64|i386|arm|ppc64|ppc64le|sparc64|ia64|alpha|ip|m68k|mips|mipsel|mk68k|mint|ppc|rs6000|s390|s390x|sh|sparc|xtensa|\*))?)$/]`
+Alias of
+
+```puppet
+Pattern[/^([0-9\*]+):([0-9a-zA-Z\._\+%\{\}\*-]+)-([^-]+)-([^-]+)\.(([0-9a-zZ-Z_\*]+)(?:\.(noarch|x86_64|i386|arm|ppc64|ppc64le|sparc64|ia64|alpha|ip|m68k|mips|mipsel|mk68k|mint|ppc|rs6000|s390|s390x|sh|sparc|xtensa|\*))?)$/]
+```
 
 ## Tasks
 
-### `init`
+### <a name="init"></a>`init`
 
 Allows you to perform yum functions
 

--- a/manifests/plugin/post_transaction_actions.pp
+++ b/manifests/plugin/post_transaction_actions.pp
@@ -1,0 +1,43 @@
+# @summary Class to install post_transaction plugin
+#
+# @see https://dnf-plugins-core.readthedocs.io/en/latest/post-transaction-actions.html DNF Post Transaction Items
+#
+# @param ensure Should the post_transaction actions plugin be installed
+#
+# @example Enable post_transaction_action plugin
+# class{'yum::plugin::post_transaction_actions':
+#   ensure => present,
+# }
+#
+class yum::plugin::post_transaction_actions (
+  Enum['present', 'absent'] $ensure = 'present',
+) {
+  if $facts['package_provider'] == 'yum' {
+    $_pkg_prefix  = undef
+    $_actionfile = '/etc/yum/post-actions/puppet_maintained.action'
+  } else {
+    $_pkg_prefix  = 'python3-dnf-plugin'
+    $_actionfile = '/etc/dnf/plugins/post-transaction-actions.d/puppet_maintained.action'
+  }
+
+  yum::plugin { 'post-transaction-actions':
+    ensure     => $ensure,
+    pkg_prefix => $_pkg_prefix,
+  }
+
+  if $ensure == 'present' {
+    concat { 'puppet_actions':
+      ensure => present,
+      path   => $_actionfile,
+      owner  => root,
+      group  => root,
+      mode   => '0644',
+    }
+
+    concat::fragment { 'action_header':
+      target  => 'puppet_actions',
+      content => "# Puppet maintained actions\n# \$key:\$state:\$command\n\n",
+      order   => '01',
+    }
+  }
+}

--- a/manifests/post_transaction_action.pp
+++ b/manifests/post_transaction_action.pp
@@ -1,0 +1,47 @@
+# @summary Creates post transaction configuratons for dnf or yum.
+#
+# @see https://dnf-plugins-core.readthedocs.io/en/latest/post-transaction-actions.html DNF Post Transaction Items
+#
+# @param action Name variable a string to label the rule
+# @param key Package name, glob or file name file glob.
+# @param state
+#    Can be `install`, `update`, `remove` or `any` on YUM based systems.
+#    Can be `in`, `out` or `any` on DNF based systems.
+# @param action The command to run
+#
+# @example Touch a file when ssh is package is updated, installed or removed.
+# yum::post_transaction_action{'touch file on ssh package update':
+#   key     => 'openssh-*',
+#   state   => 'any',
+#   command => 'touch /tmp/openssh-installed',
+# }
+#
+define yum::post_transaction_action (
+  Variant[Enum['*'],Yum::RpmNameGlob,Stdlib::Unixpath] $key,
+  String[1] $command,
+  Enum['install', 'update', 'remove', 'any', 'in', 'out'] $state = 'any',
+  String[1] $action = $title,
+) {
+  #
+  # The valid Enum is different for yum and dnf based systems.
+  #
+  if $facts['package_provider'] == 'yum' {
+    assert_type(Enum['install','update','remove','any'],$state) |$expected, $actual| {
+      fail("The state parameter on ${facts['package_provider']} based systems should be \'${expected}\' and not \'${actual}\'")
+    }
+  } else {
+    assert_type(Enum['in', 'out', 'any'],$state) |$expected, $actual| {
+      fail("The state parameter on ${facts['package_provider']} based systems should be \'${expected}\' and not \'${actual}\'")
+    }
+  }
+
+  include yum::plugin::post_transaction_actions
+
+  if $yum::plugin::post_transaction_actions::ensure == 'present' {
+    concat::fragment { "post_trans_${action}":
+      target  => 'puppet_actions',
+      content => "# Action name: ${action}\n${key}:${state}:${command}\n\n",
+      order   => '10',
+    }
+  }
+}

--- a/spec/acceptance/post_transaction_actions_spec.rb
+++ b/spec/acceptance/post_transaction_actions_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper_acceptance'
+
+describe 'yum::post_transaction_action define' do
+  context 'simple parameters' do
+    # Using puppet_apply as a helper
+    it 'must work idempotently with no errors' do
+      pp = <<-EOS
+      yum::post_transaction_action{'touch_file':
+        key     => 'vim-*',
+        command => 'touch /tmp/vim-installed',
+      }
+      yum::post_transaction_action{'second to check for conflicts':
+        key     => 'openssh-*',
+        command => 'touch /tmp/openssh-installed',
+      }
+      # Pick a package that is hopefully not installed.
+      package{'vim-enhanced':
+        ensure  => 'present',
+        require => Yum::Post_transaction_action['touch_file'],
+      }
+      EOS
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes:  true)
+    end
+    describe file('/tmp/vim-installed') do
+      it { is_expected.to be_file }
+    end
+  end
+end

--- a/spec/classes/plugin_post_transaction_actions_spec.rb
+++ b/spec/classes/plugin_post_transaction_actions_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe 'yum::plugin::post_transaction_actions' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      %w[yum dnf].each do |provider|
+        context "with package_provider #{provider}" do
+          let(:facts) do
+            os_facts.merge(package_provider: provider)
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_concat('puppet_actions') }
+          it { is_expected.to contain_concat__fragment('action_header') }
+          case provider
+          when 'yum'
+            it { is_expected.to contain_package('yum-plugin-post-transaction-actions').with_ensure('present') }
+            it { is_expected.not_to contain_package('python3-dnf-plugin-post-transaction-actions') }
+            it { is_expected.to contain_concat('puppet_actions').with_path('/etc/yum/post-actions/puppet_maintained.action') }
+          else
+            it { is_expected.to contain_package('python3-dnf-plugin-post-transaction-actions').with_ensure('present') }
+            it { is_expected.not_to contain_package('yum-plugin-post-transaction-actions') }
+            it { is_expected.to contain_concat('puppet_actions').with_path('/etc/dnf/plugins/post-transaction-actions.d/puppet_maintained.action') }
+          end
+          context 'with plugin disable' do
+            let(:params) do
+              { ensure: 'absent' }
+            end
+
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.not_to contain_concat('puppet_actions') }
+            it { is_expected.not_to contain_concat__fragment('action_header') }
+            case provider
+            when 'yum'
+              it { is_expected.to contain_package('yum-plugin-post-transaction-actions').with_ensure('absent') }
+              it { is_expected.not_to contain_package('python3-dnf-plugin-post-transaction-actions') }
+            else
+              it { is_expected.to contain_package('python3-dnf-plugin-post-transaction-actions').with_ensure('absent') }
+              it { is_expected.not_to contain_package('yum-plugin-post-transaction-actions') }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/defines/post_transaction_action_spec.rb
+++ b/spec/defines/post_transaction_action_spec.rb
@@ -1,0 +1,112 @@
+require 'spec_helper'
+
+describe 'yum::post_transaction_action' do
+  let(:title) { 'an entry' }
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      %w[yum dnf].each do |provider|
+        context "with package_provider #{provider}" do
+          let(:facts) do
+            os_facts.merge(package_provider: provider)
+          end
+
+          context 'with simple package name and state any' do
+            let(:params) do
+              {
+                key: 'openssh',
+                state: 'any',
+                command: 'foo bar',
+              }
+            end
+
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to contain_class('yum::plugin::post_transaction_actions') }
+            it { is_expected.to contain_concat__fragment('post_trans_an entry').with_content(%r{^# Action name: an entry$}) }
+            it {
+              is_expected.to contain_concat__fragment('post_trans_an entry').with(
+                {
+                  target: 'puppet_actions',
+                  order: '10',
+                  content: %r{^openssh:any:foo bar$},
+                }
+              )
+            }
+            context 'with post_transaction_actions disabled' do
+              let(:pre_condition) { 'class{"yum::plugin::post_transaction_actions": ensure => "absent"}' }
+
+              it { is_expected.to compile.with_all_deps }
+              it { is_expected.to contain_class('yum::plugin::post_transaction_actions') }
+              it { is_expected.not_to contain_concat__fragment('post_trans_an entry') }
+            end
+          end
+          context 'with package name glob and state any' do
+            let(:params) do
+              {
+                key: 'openssh-*',
+                state: 'any',
+                command: 'foo bar',
+              }
+            end
+
+            it { is_expected.to contain_concat__fragment('post_trans_an entry').with_content(%r{^openssh-\*:any:foo bar$}) }
+          end
+          context 'with file name path and state any' do
+            let(:params) do
+              {
+                key: '/etc/passwd',
+                state: 'any',
+                command: 'foo bar',
+              }
+            end
+
+            it { is_expected.to contain_concat__fragment('post_trans_an entry').with_content(%r{^/etc/passwd:any:foo bar$}) }
+          end
+          context 'with file name glob and state any' do
+            let(:params) do
+              {
+                key: '/etc/*',
+                state: 'any',
+                command: 'foo bar',
+              }
+            end
+
+            it { is_expected.to contain_concat__fragment('post_trans_an entry').with_content(%r{^/etc/\*:any:foo bar$}) }
+          end
+          context 'with simple package name and state in (dnf only option)' do
+            let(:params) do
+              {
+                key: 'openssh',
+                state: 'in',
+                command: 'foo bar',
+              }
+            end
+
+            case provider
+            when 'yum'
+              it { is_expected.to raise_error(%r{The state parameter on}) }
+            else
+              it { is_expected.to contain_concat__fragment('post_trans_an entry').with_content(%r{^openssh:in:foo bar$}) }
+            end
+          end
+          context 'with simple package name and state install (yum only option)' do
+            let(:params) do
+              {
+                key: 'openssh',
+                state: 'install',
+                command: 'foo bar',
+              }
+            end
+
+            case provider
+            when 'yum'
+              it { is_expected.to contain_concat__fragment('post_trans_an entry').with_content(%r{^openssh:install:foo bar$}) }
+            else
+              it { is_expected.to raise_error(%r{The state parameter on}) }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/type_aliases/yum_rpmnameglob_spec.rb
+++ b/spec/type_aliases/yum_rpmnameglob_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'Yum::RpmnameGlob' do
+  it { is_expected.to allow_value('python36-foobar') }
+  it { is_expected.to allow_value('openssh-*') }
+  it { is_expected.to allow_value('*-client') }
+  # confirmed that Name: puppet:agent is not permitted
+  # rpmbuild -bs ~/rpmbuild/SPECS/puppet\:agent.spec
+  # error: line 28: Illegal char ':' (0x3a) in: Name: puppet:agent
+  it { is_expected.not_to allow_values('puppet:agent*') }
+end

--- a/types/rpmnameglob.pp
+++ b/types/rpmnameglob.pp
@@ -1,0 +1,4 @@
+# @summary Valid rpm name with globs.
+# Can be alphanumeric or contain `.` `_` `+` `%` `{` `}` `-` `*`.
+# Examples python36-*, *netscape
+type Yum::RpmNameGlob = Pattern[/\A([*0-9a-zA-Z\._\+%\{\}-]+)\z/]


### PR DESCRIPTION
#### Pull Request (PR) description

A new type is added to install the post-transaction_action plugin
for YUM or DNF.

```puppet
yum::post_transaction_action{'touch_file':
  key     => 'openssh-*',
  command => 'touch /tmp/openssh-package-updated',
}
```

will touch a file every time an openssh package is installed
removed or upgraded.

https://dnf-plugins-core.readthedocs.io/en/latest/post-transaction-actions.html

