### PR TITLE
[needs validation] allow RpmNameGlob for versionlock entries

### DIFF
--- a/manifests/versionlock.pp
+++ b/manifests/versionlock.pp
@@ -76,7 +76,7 @@ define yum::versionlock (
 
     $_versionlock = "${line_prefix}${name}"
   } else {
-    assert_type(Yum::RpmName, $name) |$_expected, $actual | {
+    assert_type(Yum::RpmNameGlob, $name) |$_expected, $actual | {
       fail("Package name must be formatted as Yum::RpmName, not \'${actual}\'. See Yum::Rpmname documentation for details.")
     }
 


### PR DESCRIPTION
As stated in the manpage [1] yum versionlock supports package-wildcard
and does not require exact matches for package-names.
The following is valid `versionlock.list` content:
```
libvirt*-0:7.6.0-*.*
qemu*-0:6.1.0-*.*
```

This commit swaps `Yum::RpmName` with `Yum::RpmNameGlob` for the
versionlock `assert_type()` and thus allowing the above mentioned
examples.

[1] https://man7.org/linux/man-pages/man1/yum-versionlock.1.html