### PR TITLE
Allow arch aarch64 in yum::versionlock

### DIFF
--- a/spec/type_aliases/yum_rpmarch_spec.rb
+++ b/spec/type_aliases/yum_rpmarch_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe 'Yum::Rpmarch' do
   it { is_expected.to allow_value('x86_64') }
+  it { is_expected.to allow_value('aarch64') }
   it { is_expected.to allow_value('noarch') }
   it { is_expected.not_to allow_values('quantum') }
 end

--- a/types/rpmarch.pp
+++ b/types/rpmarch.pp
@@ -5,6 +5,7 @@ type Yum::RpmArch = Enum[
   'noarch',
   'x86_64',
   'i386',
+  'aarch64',
   'arm',
   'ppc64',
   'ppc64le',


### PR DESCRIPTION
#### This Pull Request (PR) fixes the following issues

Add aarch64 as a possible for architecture of a versionlock.

Currently

```puppet
yum::versionlock{['glog','glog-devel']:
  ensure  => present,
  version => '0.3.5',
  release => '4.el8',
  arch    => 'aarch64'
}
```

fails despite:

```bash
rpm -q --queryformat '%{name} %{version} %{release} %{arch}\n' glog
glog 0.3.5 4.el8 aarch64
```
