### PR TITLE
sync with upstream AlmaLinux repository set

### DIFF
--- a/data/os/RedHat/AlmaLinux.yaml
+++ b/data/os/RedHat/AlmaLinux.yaml
@@ -4,30 +4,39 @@ yum::os_default_repos:
   - 'appstream'
   - 'powertools'
   - 'extras'
+  - 'ha'
+  - 'plus'
+  - 'resilientstorage'
   - 'baseos-source'
   - 'appstream-source'
   - 'powertools-source'
   - 'extras-source'
+  - 'ha-source'
+  - 'plus-source'
+  - 'resilientstorage-source'
   - 'baseos-debuginfo'
   - 'appstream-debuginfo'
   - 'powertools-debuginfo'
   - 'extras-debuginfo'
+  - 'ha-debuginfo'
+  - 'plus-debuginfo'
+  - 'resilientstorage-debuginfo'
 
 yum::repos:
   baseos:
-    enabled: true
     descr: 'AlmaLinux-$releasever - BaseOS'
     mirrorlist: 'https://mirrors.almalinux.org/mirrorlist/$releasever/baseos'
     # baseurl: https://repo.almalinux.org/almalinux/$releasever/BaseOS/$basearch/os/
+    enabled: true
     gpgcheck: true
     gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux'
     target: '/etc/yum.repos.d/almalinux.repo'
 
   appstream:
-    enabled: true
     descr: 'AlmaLinux $releasever - AppStream'
     mirrorlist: 'https://mirrors.almalinux.org/mirrorlist/$releasever/appstream'
     # baseurl: https://repo.almalinux.org/almalinux/$releasever/AppStream/$basearch/os/
+    enabled: true
     gpgcheck: true
     gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux"
     target: '/etc/yum.repos.d/almalinux.repo'
@@ -39,75 +48,157 @@ yum::repos:
     enabled: true
     gpgcheck: true
     gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux'
+    target: '/etc/yum.repos.d/almalinux-powertools.repo'
 
   extras:
-    name: 'AlmaLinux $releasever - Extras'
+    descr: 'AlmaLinux $releasever - Extras'
     mirrorlist: 'https://mirrors.almalinux.org/mirrorlist/$releasever/extras'
     # baseurl: https://repo.almalinux.org/almalinux/$releasever/extras/$basearch/os/
     enabled: true
     gpgcheck: true
     gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux'
+    target: '/etc/yum.repos.d/almalinux.repo'
+
+  ha:
+    descr: 'AlmaLinux $releasever - HighAvailability'
+    mirrorlist: 'https://mirrors.almalinux.org/mirrorlist/$releasever/ha'
+    enabled: false
+    gpgcheck: true
+    gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux'
+    target: '/etc/yum.repos.d/almalinux-ha.repo'
+
+  plus:
+    descr: 'AlmaLinux $releasever - Plus'
+    mirrorlist: 'https://mirrors.almalinux.org/mirrorlist/$releasever/plus'
+    enabled: false
+    gpgcheck: true
+    gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux'
+    target: '/etc/yum.repos.d/almalinux-plus.repo'
+
+  resilientstorage:
+    descr: AlmaLinux $releasever - ResilientStorage
+    mirrorlist: https://mirrors.almalinux.org/mirrorlist/$releasever/resilientstorage
+    enabled: false
+    gpgcheck: true
+    gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux'
+    target: '/etc/yum.repos.d/almalinux-resilientstorage.repo'
 
   baseos-source:
-    name: 'AlmaLinux $releasever - BaseOS Source'
+    descr: 'AlmaLinux $releasever - BaseOS Source'
     mirrorlist: 'https://mirrors.almalinux.org/mirrorlist/$releasever/baseos-source'
     # baseurl: https://repo.almalinux.org/almalinux/$releasever/BaseOS/Source/
     enabled: false
     gpgcheck: true
     gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux'
+    target: '/etc/yum.repos.d/almalinux.repo'
 
   appstream-source:
-    name: 'AlmaLinux $releasever - AppStream Source'
+    descr: 'AlmaLinux $releasever - AppStream Source'
     mirrorlist: 'https://mirrors.almalinux.org/mirrorlist/$releasever/appstream-source'
     # baseurl: https://repo.almalinux.org/almalinux/$releasever/AppStream/Source/
     enabled: false
     gpgcheck: true
     gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux'
+    target: '/etc/yum.repos.d/almalinux.repo'
 
   powertools-source:
-    name: 'AlmaLinux $releasever - PowerTools Source'
+    descr: 'AlmaLinux $releasever - PowerTools Source'
     mirrorlist: 'https://mirrors.almalinux.org/mirrorlist/$releasever/powertools-source'
     # baseurl: https://repo.almalinux.org/almalinux/$releasever/PowerTools/Source/
     enabled: false
     gpgcheck: true
     gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux'
+    target: '/etc/yum.repos.d/almalinux-powertools.repo'
 
   extras-source:
-    name: 'AlmaLinux $releasever - Extras Source'
+    descr: 'AlmaLinux $releasever - Extras Source'
     mirrorlist: 'https://mirrors.almalinux.org/mirrorlist/$releasever/extras-source'
     # baseurl: https://repo.almalinux.org/almalinux/$releasever/extras/Source/
     enabled: false
     gpgcheck: true
     gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux'
+    target: '/etc/yum.repos.d/almalinux.repo'
+
+  ha-source:
+    descr: 'AlmaLinux $releasever - HighAvailability Source'
+    enabled: false
+    gpgcheck: true
+    gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux'
+    mirrorlist: 'https://mirrors.almalinux.org/mirrorlist/$releasever/ha-source'
+    target: '/etc/yum.repos.d/almalinux-ha.repo'
+
+  plus-source:
+    descr: 'AlmaLinux $releasever - Plus Source'
+    enabled: false
+    gpgcheck: true
+    gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux'
+    mirrorlist: 'https://mirrors.almalinux.org/mirrorlist/$releasever/plus-source'
+    target: '/etc/yum.repos.d/almalinux-plus.repo'
+
+  resilientstorage-source:
+    descr: 'AlmaLinux $releasever - ResilientStorage Source'
+    enabled: false
+    gpgcheck: true
+    gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux'
+    mirrorlist: 'https://mirrors.almalinux.org/mirrorlist/$releasever/resilientstorage-source'
+    target: '/etc/yum.repos.d/almalinux-resilientstorage.repo'
 
   baseos-debuginfo:
-    name: 'AlmaLinux $releasever - BaseOS debuginfo'
+    descr: 'AlmaLinux $releasever - BaseOS debuginfo'
     mirrorlist: 'https://mirrors.almalinux.org/mirrorlist/$releasever/baseos-debuginfo'
     # baseurl: https://repo.almalinux.org/almalinux/$releasever/BaseOS/debug/$basearch/
     enabled: false
     gpgcheck: true
     gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux'
+    target: '/etc/yum.repos.d/almalinux.repo'
 
   appstream-debuginfo:
-    name: 'AlmaLinux $releasever - AppStream debuginfo'
+    descr: 'AlmaLinux $releasever - AppStream debuginfo'
     mirrorlist: 'https://mirrors.almalinux.org/mirrorlist/$releasever/appstream-debuginfo'
     # baseurl: https://repo.almalinux.org/almalinux/$releasever/AppStream/debug/$basearch/
     enabled: false
     gpgcheck: true
     gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux'
+    target: '/etc/yum.repos.d/almalinux.repo'
 
   powertools-debuginfo:
-    name: 'AlmaLinux $releasever - PowerTools debuginfo'
+    descr: 'AlmaLinux $releasever - PowerTools debuginfo'
     mirrorlist: 'https://mirrors.almalinux.org/mirrorlist/$releasever/powertools-debuginfo'
     # baseurl: https://repo.almalinux.org/almalinux/$releasever/PowerTools/debug/$basearch/
     enabled: false
     gpgcheck: true
     gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux'
+    target: '/etc/yum.repos.d/almalinux-powertools.repo'
 
   extras-debuginfo:
-    name: 'AlmaLinux $releasever - Extras debuginfo'
+    descr: 'AlmaLinux $releasever - Extras debuginfo'
     mirrorlist: 'https://mirrors.almalinux.org/mirrorlist/$releasever/extras-debuginfo'
     # baseurl: https://repo.almalinux.org/almalinux/$releasever/extras/debug/$basearch/
     enabled: false
     gpgcheck: true
     gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux'
+    target: '/etc/yum.repos.d/almalinux.repo'
+
+  ha-debuginfo:
+    descr: 'AlmaLinux $releasever - HighAvailability debuginfo'
+    enabled: false
+    gpgcheck: true
+    gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux'
+    mirrorlist: 'https://mirrors.almalinux.org/mirrorlist/$releasever/ha-debuginfo'
+    target: '/etc/yum.repos.d/almalinux-ha.repo'
+
+  plus-debuginfo:
+    descr: 'AlmaLinux $releasever - Plus debuginfo'
+    enabled: false
+    gpgcheck: true
+    gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux'
+    mirrorlist: 'https://mirrors.almalinux.org/mirrorlist/$releasever/plus-debuginfo'
+    target: '/etc/yum.repos.d/almalinux-plus.repo'
+
+  resilientstorage-debuginfo:
+    descr: 'AlmaLinux $releasever - ResilientStorage debuginfo'
+    enabled: false
+    gpgcheck: true
+    gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux'
+    mirrorlist: 'https://mirrors.almalinux.org/mirrorlist/$releasever/resilientstorage-debuginfo'
+    target: '/etc/yum.repos.d/almalinux-resilientstorage.repo'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -195,7 +195,7 @@ describe 'yum' do
         when 'VirtuozzoLinux'
           case facts[:os]['release']['major']
           when '6'
-            it { is_expected.to have_yumrepo_resource_count(12) } # rubocop:disable RSpec/RepeatedExample
+            it { is_expected.to have_yumrepo_resource_count(12) }
 
             it_behaves_like 'a catalog containing repos', %w[
               virtuozzolinux-base
@@ -236,7 +236,7 @@ describe 'yum' do
         when 'AlmaLinux'
           case facts[:os]['release']['major']
           when '8'
-            it { is_expected.to have_yumrepo_resource_count(21) } # rubocop:disable RSpec/RepeatedExample
+            it { is_expected.to have_yumrepo_resource_count(21) }
 
             it_behaves_like 'a catalog containing repos', %w[
               baseos
@@ -374,7 +374,7 @@ describe 'yum' do
           when 'VirtuozzoLinux'
             case facts[:os]['release']['major']
             when '6'
-              it { is_expected.to have_yumrepo_resource_count(12) } # rubocop:disable RSpec/RepeatedExample
+              it { is_expected.to have_yumrepo_resource_count(12) }
 
               it_behaves_like 'a catalog containing repos', %w[
                 virtuozzolinux-base
@@ -415,7 +415,7 @@ describe 'yum' do
           when 'AlmaLinux'
             case facts[:os]['release']['major']
             when '8'
-              it { is_expected.to have_yumrepo_resource_count(21) } # rubocop:disable RSpec/RepeatedExample
+              it { is_expected.to have_yumrepo_resource_count(21) }
 
               it_behaves_like 'a catalog containing repos', %w[
                 baseos

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -236,21 +236,30 @@ describe 'yum' do
         when 'AlmaLinux'
           case facts[:os]['release']['major']
           when '8'
-            it { is_expected.to have_yumrepo_resource_count(12) } # rubocop:disable RSpec/RepeatedExample
+            it { is_expected.to have_yumrepo_resource_count(21) } # rubocop:disable RSpec/RepeatedExample
 
             it_behaves_like 'a catalog containing repos', %w[
               baseos
               appstream
               powertools
               extras
+              ha
+              plus
+              resilientstorage
               baseos-source
               appstream-source
               powertools-source
               extras-source
+              ha-source
+              plus-source
+              resilientstorage-source
               baseos-debuginfo
               appstream-debuginfo
               powertools-debuginfo
               extras-debuginfo
+              ha-debuginfo
+              plus-debuginfo
+              resilientstorage-debuginfo
             ]
           end
         else
@@ -406,21 +415,30 @@ describe 'yum' do
           when 'AlmaLinux'
             case facts[:os]['release']['major']
             when '8'
-              it { is_expected.to have_yumrepo_resource_count(12) } # rubocop:disable RSpec/RepeatedExample
+              it { is_expected.to have_yumrepo_resource_count(21) } # rubocop:disable RSpec/RepeatedExample
 
               it_behaves_like 'a catalog containing repos', %w[
                 baseos
                 appstream
                 powertools
                 extras
+                ha
+                plus
+                resilientstorage
                 baseos-source
                 appstream-source
                 powertools-source
                 extras-source
+                ha-source
+                plus-source
+                resilientstorage-source
                 baseos-debuginfo
                 appstream-debuginfo
                 powertools-debuginfo
                 extras-debuginfo
+                ha-debuginfo
+                plus-debuginfo
+                resilientstorage-debuginfo
               ]
             end
           when 'Rocky'


### PR DESCRIPTION
#### Pull Request (PR) description
sync with upstream AlmaLinux repository set

AlmaLinux now provides additional repositories - ha, plus and resilient storage

#### This Pull Request (PR) fixes the following issues
Previously, several repositories have been misconfigured, since descr is a required field
Considering that yumrepo will finally implement target soon, fix targets as well

