### PR TITLE
Avoid assumption that package_provider is set

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -17,3 +17,6 @@ lookup_options:
     merge: 'unique'
   yum::repo_exclusions:
     merge: 'unique'
+
+# Default is currently yum path
+yum::plugin::versionlock::path: /etc/yum/pluginconf.d/versionlock.list

--- a/data/package_provider/yum.yaml
+++ b/data/package_provider/yum.yaml
@@ -1,2 +1,0 @@
----
-yum::plugin::versionlock::path: /etc/yum/pluginconf.d/versionlock.list

--- a/spec/defines/post_transaction_action_spec.rb
+++ b/spec/defines/post_transaction_action_spec.rb
@@ -7,10 +7,26 @@ describe 'yum::post_transaction_action' do
 
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
+      let(:facts) do
+        os_facts
+      end
+
+      context 'with_package_provider unset' do
+        let(:params) do
+          {
+            key: 'openssh',
+            state: 'any',
+            command: 'foo bar',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+      end
+
       %w[yum dnf].each do |provider|
         context "with package_provider #{provider}" do
           let(:facts) do
-            os_facts.merge(package_provider: provider)
+            super().merge(package_provider: provider)
           end
 
           context 'with simple package name and state any' do

--- a/spec/defines/versionlock_spec.rb
+++ b/spec/defines/versionlock_spec.rb
@@ -196,4 +196,18 @@ describe 'yum::versionlock' do
       end
     end
   end
+
+  context 'with package_provider unset' do
+    let(:facts) do
+      { os: { release: { major: 7 } } }
+    end
+    let(:title) { 'bash' }
+    let(:params) { { version: '4.3' } }
+
+    it { is_expected.to compile.with_all_deps }
+
+    it 'contains a well-formed Concat::Fragment' do
+      is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-0:4.3-*.*\n")
+    end
+  end
 end


### PR DESCRIPTION
#### Pull Request (PR) description

With the changes in https://github.com/voxpupuli/puppet-yum/pull/253 `yum::versionlock` was failing for cases where
`$facts['package_provider]` was unset which is typically the case for rspec compilations.

Default `yum::versionlock::path` to the existing yum location.
