### PR TITLE
Use standard directory permissions

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -123,7 +123,7 @@ class yum (
     ensure  => 'directory',
     owner   => 'root',
     group   => 'root',
-    mode    => '0644',
+    mode    => '0755',
     recurse => true,
     purge   => $purge_unmanaged_repos,
   }


### PR DESCRIPTION
#### Pull Request (PR) description

With a recent commit the module started to manage `/etc/yum.repos.d`. Unfortunately the non-standard directory mode `0644` is used.

This PR changes the directory mode to the more suitable `0755`.
