### PR TITLE
versionlock.pp: Prevent multiple concat declarations

### DIFF
--- a/manifests/plugin/versionlock.pp
+++ b/manifests/plugin/versionlock.pp
@@ -33,11 +33,13 @@ class yum::plugin::versionlock (
       false => undef,
     }
 
-    concat { $path:
-      mode   => '0644',
-      owner  => 'root',
-      group  => 'root',
-      notify => $_clean_notify,
+    unless defined(Concat[$path]) {
+      concat { $path:
+        mode   => '0644',
+        owner  => 'root',
+        group  => 'root',
+        notify => $_clean_notify,
+      }
     }
 
     concat::fragment { 'versionlock_header':


### PR DESCRIPTION
#### Pull Request (PR) description
When `yum::versionlock` is declared multiple times, our pipeline is failing due to dependency cyles on `Concat_file[/etc/yum/pluginconf.d/versionlock.list]`.

So this change ensure that the `concat`'ed versionlock file is declared only once.

#### This Pull Request (PR) fixes the following issues
N/A