### PR TITLE
Add sensitive support for configs

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,7 +18,6 @@ define yum::config (
   Variant[Boolean, Integer, Enum['absent'], String, Sensitive[String]] $ensure,
   String                                            $key     = $title,
 ) {
-
   $_ensure = $ensure ? {
     Boolean   => bool2num($ensure),
     Sensitive => $ensure.unwrap,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,12 +15,14 @@
 #   }
 #
 define yum::config (
-  Variant[Boolean, Integer, Enum['absent'], String] $ensure,
+  Variant[Boolean, Integer, Enum['absent'], String, Sensitive[String]] $ensure,
   String                                            $key     = $title,
 ) {
+
   $_ensure = $ensure ? {
-    Boolean => bool2num($ensure),
-    default => $ensure,
+    Boolean   => bool2num($ensure),
+    Sensitive => $ensure.unwrap,
+    default   => $ensure,
   }
 
   $_changes = $ensure ? {
@@ -28,10 +30,16 @@ define yum::config (
     default   => "set ${key} '${_ensure}'",
   }
 
+  $_show_diff = $ensure ? {
+    Sensitive => false,
+    default   => true,
+  }
+
   augeas { "yum.conf_${key}":
-    incl    => '/etc/yum.conf',
-    lens    => 'Yum.lns',
-    context => '/files/etc/yum.conf/main/',
-    changes => $_changes,
+    incl      => '/etc/yum.conf',
+    lens      => 'Yum.lns',
+    context   => '/files/etc/yum.conf/main/',
+    changes   => $_changes,
+    show_diff => $_show_diff,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,8 @@
 #   are either the direct `ensure` value, or a Hash of the resource's attributes.
 #
 #   @note Boolean parameter values will be converted to either a `1` or `0`; use a quoted string to
-#     get a literal `true` or `false`.
+#     get a literal `true` or `false`. Sensitive value will disable the `show_diff`.
+#
 #
 # @param repos
 #   A hash where keys are the names of `Yumrepo` resources and each value represents its respective
@@ -102,7 +103,7 @@
 class yum (
   Boolean $clean_old_kernels = true,
   Boolean $keep_kernel_devel = false,
-  Hash[String, Variant[String, Integer, Boolean, Hash[String, Variant[String, Integer, Boolean]]]] $config_options = {},
+  Hash[String, Variant[String, Integer, Boolean, Sensitive[String], Hash[String, Variant[String, Integer, Boolean, Sensitive[String]]]]] $config_options = {},
   Hash[String, Optional[Hash[String, Variant[String, Integer, Boolean]]]] $repos = {},
   Array[String] $managed_repos = [],
   Boolean $manage_os_default_repos = false,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -633,6 +633,14 @@ describe 'yum' do
           it_behaves_like 'a Yum class'
         end
 
+        context 'to a Sensitive value' do
+          let(:params) { { config_options: { 'proxy_password' => sensitive('secret') } } }
+
+          it { is_expected.to contain_yum__config('proxy_password').with_ensure('Sensitive [value redacted]') }
+
+          it_behaves_like 'a Yum class'
+        end
+
         context 'using the nested attributes syntax' do
           context 'to a String' do
             let(:params) { { config_options: { 'my_cachedir' => { 'ensure' => '/var/cache/yum', 'key' => 'cachedir' } } } }

--- a/spec/defines/config_spec.rb
+++ b/spec/defines/config_spec.rb
@@ -47,4 +47,18 @@ describe 'yum::config' do
       )
     end
   end
+
+  context 'when ensure is a Sensitive[String]' do
+    let(:title) { 'assumeyes' }
+    let(:params) { { ensure: sensitive('secret') } }
+
+    it { is_expected.to compile.with_all_deps }
+
+    it 'contains an Augeas resource with the correct changes' do
+      is_expected.to contain_augeas("yum.conf_#{title}").with(
+        changes: "set assumeyes 'secret'",
+        show_diff: false
+      )
+    end
+  end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
I would like the `proxy_password` config not be leaked in the puppet log.  This PR address this issue by disabling the `show_diff` when the given config is of type `Sensitive`

```
class example {
  $secret = Sensitive('mysecretpassword')
  class { 'yum' :
    config_options => {
      'proxy'          => 'https://host.example.com:3128',
      'proxy_username' => 'user',
      'proxy_password' => $secret,
    },
  }
}
```

I could add support for `Sensitive[Boolean]` and `Sensitive[Integer]` also if you think it is necessary, feel free to ask for it.  I was not sure it would be required.