### PR TITLE
Option to disable display of diff in the puppet log

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,39 @@ yum::config { 'debuglevel':
 }
 ```
 
+NOTE: The parameter `ensure` can be set as sensitive, but is not censored when
+another config nearby is changed. For example:
+
+```puppet
+yum::config { 'proxy_username':
+  ensure => 'user',
+}
+yum::config { 'proxy_password':
+  ensure => Sensitive('mysecretpassword'),
+}
+```
+
+```bash
+--- /etc/yum.conf       2022-09-28 10:53:13.958280359 -0400
++++ /etc/yum.conf.augnew        2022-09-28 11:44:01.581689900 -0400
+@@ -10,5 +10,5 @@
+ metadata_expire=0
+ mirrorlist_expire=0
+ proxy=http://host.example.com:3128
+-proxy_username=user
++proxy_username=anotheruser
+ proxy_password=mysecretpassword
+
+Notice: /Stage[main]/Yum/Yum::Config[proxy_username]/Augeas[yum.conf_proxy_username]/returns: executed successfully (corrective)
+```
+
+The parameter `show_diff => false` should be use in this case:
+```puppet
+class { 'yum':
+  show_diff => false,
+}
+```
+
 ### Manage COPR repositories
 
 This module also supports managing

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -132,6 +132,7 @@ The following parameters are available in the `yum` class:
 * [`gpgkeys`](#-yum--gpgkeys)
 * [`utils_package_name`](#-yum--utils_package_name)
 * [`groups`](#-yum--groups)
+* [`show_diff`](#-yum--show_diff)
 
 ##### <a name="-yum--clean_old_kernels"></a>`clean_old_kernels`
 
@@ -244,6 +245,15 @@ Data type: `Stdlib::CreateResources`
 A hash of yum::group instances to manage.
 
 Default value: `{}`
+
+##### <a name="-yum--show_diff"></a>`show_diff`
+
+Data type: `Boolean`
+
+Wether to display diff when a config is changed.  It is useful when there is confidental
+information that you do not want displayed in the puppet logs.
+
+Default value: `true`
 
 ### <a name="yum--clean"></a>`yum::clean`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,6 +18,7 @@ define yum::config (
   Variant[Boolean, Integer, Enum['absent'], String, Sensitive[String]] $ensure,
   String                                            $key     = $title,
 ) {
+  include yum
   include yum::settings
   $_mainconf = $yum::settings::mainconf
 
@@ -34,7 +35,7 @@ define yum::config (
 
   $_show_diff = $ensure ? {
     Sensitive => false,
-    default   => true,
+    default   => $yum::show_diff,
   }
 
   augeas { "${facts['package_provider']}.conf_${key}":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,6 +58,10 @@
 # @param groups
 #   A hash of yum::group instances to manage.
 #
+# @param show_diff
+#   Wether to display diff when a config is changed.  It is useful when there is confidental
+#   information that you do not want displayed in the puppet logs.
+#
 # @example Enable management of the default repos for a supported OS:
 #   ---
 #   yum::manage_os_default_repos: true
@@ -116,7 +120,8 @@ class yum (
   Array[String] $repo_exclusions = [],
   Hash[String, Hash[String, String]] $gpgkeys = {},
   String $utils_package_name = 'yum-utils',
-  Stdlib::CreateResources $groups = {}
+  Stdlib::CreateResources $groups = {},
+  Boolean $show_diff = true,
 ) {
   $module_metadata            = load_module_metadata($module_name)
   $supported_operatingsystems = $module_metadata['operatingsystem_support']

--- a/spec/defines/config_spec.rb
+++ b/spec/defines/config_spec.rb
@@ -3,98 +3,106 @@
 require 'spec_helper'
 
 describe 'yum::config' do
-  context 'with no parameters' do
-    let(:title) { 'assumeyes' }
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
 
-    it { is_expected.to compile.and_raise_error(%r{expects a value for parameter 'ensure'}) }
-  end
-
-  %w[dnf yum].each do |pkgmgr|
-    context "when package_provider fact is #{pkgmgr}" do
-      let(:facts) { { package_provider: pkgmgr } }
-
-      context 'when ensure is a Boolean' do
+      context 'with no parameters' do
         let(:title) { 'assumeyes' }
-        let(:params) { { ensure: true } }
 
-        it { is_expected.to compile.with_all_deps }
-
-        it 'contains an Augeas resource with the correct changes' do
-          case pkgmgr
-          when 'yum'
-            is_expected.to contain_augeas("yum.conf_#{title}").with(
-              incl: '/etc/yum.conf',
-              context: '/files/etc/yum.conf/main/',
-              changes: "set assumeyes '1'"
-            )
-          else
-            is_expected.to contain_augeas("dnf.conf_#{title}").with(
-              incl: '/etc/dnf/dnf.conf',
-              context: '/files/etc/dnf/dnf.conf/main/',
-              changes: "set assumeyes '1'"
-            )
-          end
-        end
+        it { is_expected.to compile.and_raise_error(%r{expects a value for parameter 'ensure'}) }
       end
 
-      context 'ensure is an Integer' do
-        let(:title) { 'assumeyes' }
-        let(:params) { { ensure: 0 } }
-
-        it { is_expected.to compile.with_all_deps }
-
-        it 'contains an Augeas resource with the correct changes' do
-          case pkgmgr
-          when 'yum'
-            is_expected.to contain_augeas("yum.conf_#{title}").with(
-              changes: "set assumeyes '0'"
-            )
-          else
-            is_expected.to contain_augeas("dnf.conf_#{title}").with(
-              changes: "set assumeyes '0'"
-            )
+      %w[dnf yum].each do |pkgmgr|
+        context "when package_provider fact is #{pkgmgr}" do
+          let(:facts) do
+            super().merge({ package_provider: pkgmgr })
           end
-        end
-      end
 
-      context 'ensure is a comma separated String' do
-        let(:title) { 'assumeyes' }
-        let(:params) { { ensure: '1, 2' } }
+          context 'when ensure is a Boolean' do
+            let(:title) { 'assumeyes' }
+            let(:params) { { ensure: true } }
 
-        it { is_expected.to compile.with_all_deps }
+            it { is_expected.to compile.with_all_deps }
 
-        it 'contains an Augeas resource with the correct changes' do
-          case pkgmgr
-          when 'yum'
-            is_expected.to contain_augeas("yum.conf_#{title}").with(
-              changes: "set assumeyes '1, 2'"
-            )
-          else
-            is_expected.to contain_augeas("dnf.conf_#{title}").with(
-              changes: "set assumeyes '1, 2'"
-            )
+            it 'contains an Augeas resource with the correct changes' do
+              case pkgmgr
+              when 'yum'
+                is_expected.to contain_augeas("yum.conf_#{title}").with(
+                  incl: '/etc/yum.conf',
+                  context: '/files/etc/yum.conf/main/',
+                  changes: "set assumeyes '1'"
+                )
+              else
+                is_expected.to contain_augeas("dnf.conf_#{title}").with(
+                  incl: '/etc/dnf/dnf.conf',
+                  context: '/files/etc/dnf/dnf.conf/main/',
+                  changes: "set assumeyes '1'"
+                )
+              end
+            end
           end
-        end
-      end
 
-      context 'when ensure is a Sensitive[String]' do
-        let(:title) { 'assumeyes' }
-        let(:params) { { ensure: sensitive('secret') } }
+          context 'ensure is an Integer' do
+            let(:title) { 'assumeyes' }
+            let(:params) { { ensure: 0 } }
 
-        it { is_expected.to compile.with_all_deps }
+            it { is_expected.to compile.with_all_deps }
 
-        it 'contains an Augeas resource with the correct changes' do
-          case pkgmgr
-          when 'yum'
-            is_expected.to contain_augeas("yum.conf_#{title}").with(
-              changes: "set assumeyes 'secret'",
-              show_diff: false
-            )
-          else
-            is_expected.to contain_augeas("dnf.conf_#{title}").with(
-              changes: "set assumeyes 'secret'",
-              show_diff: false
-            )
+            it 'contains an Augeas resource with the correct changes' do
+              case pkgmgr
+              when 'yum'
+                is_expected.to contain_augeas("yum.conf_#{title}").with(
+                  changes: "set assumeyes '0'"
+                )
+              else
+                is_expected.to contain_augeas("dnf.conf_#{title}").with(
+                  changes: "set assumeyes '0'"
+                )
+              end
+            end
+          end
+
+          context 'ensure is a comma separated String' do
+            let(:title) { 'assumeyes' }
+            let(:params) { { ensure: '1, 2' } }
+
+            it { is_expected.to compile.with_all_deps }
+
+            it 'contains an Augeas resource with the correct changes' do
+              case pkgmgr
+              when 'yum'
+                is_expected.to contain_augeas("yum.conf_#{title}").with(
+                  changes: "set assumeyes '1, 2'"
+                )
+              else
+                is_expected.to contain_augeas("dnf.conf_#{title}").with(
+                  changes: "set assumeyes '1, 2'"
+                )
+              end
+            end
+          end
+
+          context 'when ensure is a Sensitive[String]' do
+            let(:title) { 'assumeyes' }
+            let(:params) { { ensure: sensitive('secret') } }
+
+            it { is_expected.to compile.with_all_deps }
+
+            it 'contains an Augeas resource with the correct changes' do
+              case pkgmgr
+              when 'yum'
+                is_expected.to contain_augeas("yum.conf_#{title}").with(
+                  changes: "set assumeyes 'secret'",
+                  show_diff: false
+                )
+              else
+                is_expected.to contain_augeas("dnf.conf_#{title}").with(
+                  changes: "set assumeyes 'secret'",
+                  show_diff: false
+                )
+              end
+            end
           end
         end
       end

--- a/spec/defines/config_spec.rb
+++ b/spec/defines/config_spec.rb
@@ -104,6 +104,29 @@ describe 'yum::config' do
               end
             end
           end
+
+          context 'when show_diff is disabled in yum::show_diff' do
+            let(:title) { 'assumeyes' }
+            let(:params) { { ensure: '1, 2' } }
+            let(:pre_condition) { 'class { yum : show_diff => false }' }
+
+            it { is_expected.to compile.with_all_deps }
+
+            it 'contains an Augeas resource with the correct changes' do
+              case pkgmgr
+              when 'yum'
+                is_expected.to contain_augeas("yum.conf_#{title}").with(
+                  changes: "set assumeyes '1, 2'",
+                  show_diff: false
+                )
+              else
+                is_expected.to contain_augeas("dnf.conf_#{title}").with(
+                  changes: "set assumeyes '1, 2'",
+                  show_diff: false
+                )
+              end
+            end
+          end
         end
       end
     end

--- a/spec/defines/versionlock_spec.rb
+++ b/spec/defines/versionlock_spec.rb
@@ -3,211 +3,211 @@
 require 'spec_helper'
 
 describe 'yum::versionlock' do
-  context 'with package_provider set to yum' do
-    let(:facts) do
-      { os: { release: { major: 7 } },
-        package_provider: 'yum' }
-    end
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
 
-    context 'with a simple, well-formed title 0:bash-4.1.2-9.el6_2.x86_64' do
-      let(:title) { '0:bash-4.1.2-9.el6_2.x86_64' }
-
-      context 'and no parameters' do
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_concat__fragment('versionlock_header').with_content("# File managed by puppet\n") }
-
-        it 'contains a well-formed Concat::Fragment' do
-          is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("#{title}\n")
+      context 'with package_provider set to yum' do
+        let(:facts) do
+          super().merge({ package_provider: 'yum' })
         end
 
-        it { is_expected.to contain_concat('/etc/yum/pluginconf.d/versionlock.list').without_notify }
-      end
+        context 'with a simple, well-formed title 0:bash-4.1.2-9.el6_2.x86_64' do
+          let(:title) { '0:bash-4.1.2-9.el6_2.x86_64' }
 
-      context 'clean set to true on module' do
-        let :pre_condition do
-          'class { "yum::plugin::versionlock": clean => true, }'
+          context 'and no parameters' do
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to contain_concat__fragment('versionlock_header').with_content("# File managed by puppet\n") }
+
+            it 'contains a well-formed Concat::Fragment' do
+              is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("#{title}\n")
+            end
+
+            it { is_expected.to contain_concat('/etc/yum/pluginconf.d/versionlock.list').without_notify }
+          end
+
+          context 'clean set to true on module' do
+            let :pre_condition do
+              'class { "yum::plugin::versionlock": clean => true, }'
+            end
+
+            it { is_expected.to contain_concat('/etc/yum/pluginconf.d/versionlock.list').with_notify('Exec[yum_clean_all]') }
+            it { is_expected.to contain_exec('yum_clean_all').with_command('/usr/bin/yum clean all') }
+          end
+
+          context 'and ensure set to present' do
+            let(:params) { { ensure: 'present' } }
+
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to contain_concat__fragment('versionlock_header').with_content("# File managed by puppet\n") }
+
+            it 'contains a well-formed Concat::Fragment' do
+              is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("#{title}\n")
+            end
+          end
+
+          context 'and ensure set to absent' do
+            let(:params) { { ensure: 'absent' } }
+
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to contain_concat__fragment('versionlock_header').with_content("# File managed by puppet\n") }
+
+            it 'contains a well-formed Concat::Fragment' do
+              is_expected.not_to contain_concat__fragment("yum-versionlock-#{title}")
+            end
+          end
+
+          context 'with version set namevar must be just a package name' do
+            let(:params) { { version: '4.3' } }
+
+            it { is_expected.to compile.and_raise_error(%r{Package name must be formatted as Yum::RpmName, not 'String'}) }
+          end
         end
 
-        it { is_expected.to contain_concat('/etc/yum/pluginconf.d/versionlock.list').with_notify('Exec[yum_clean_all]') }
-        it { is_expected.to contain_exec('yum_clean_all').with_command('/usr/bin/yum clean all') }
-      end
+        context 'with a trailing wildcard title' do
+          let(:title) { '0:bash-4.1.2-9.el6_2.*' }
 
-      context 'and ensure set to present' do
-        let(:params) { { ensure: 'present' } }
+          it { is_expected.to compile.with_all_deps }
 
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_concat__fragment('versionlock_header').with_content("# File managed by puppet\n") }
+          it 'contains a well-formed Concat::Fragment' do
+            is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("#{title}\n")
+          end
+        end
 
-        it 'contains a well-formed Concat::Fragment' do
-          is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("#{title}\n")
+        context 'with a complex wildcard title' do
+          let(:title) { '0:bash-4.*-*.el6' }
+
+          it 'contains a well-formed Concat::Fragment' do
+            is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("#{title}\n")
+          end
+        end
+
+        context 'with a release containing dots' do
+          let(:title) { '1:java-1.7.0-openjdk-1.7.0.121-2.6.8.0.el7_3.x86_64' }
+
+          it 'contains a well-formed Concat::Fragment' do
+            is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("#{title}\n")
+          end
+        end
+
+        context 'with an invalid title' do
+          let(:title) { 'bash-4.1.2' }
+
+          it { is_expected.to compile.and_raise_error(%r(%\{EPOCH\}:%\{NAME\}-%\{VERSION\}-%\{RELEASE\}\.%\{ARCH\})) }
+        end
+
+        context 'with an invalid wildcard pattern' do
+          let(:title) { '0:bash-4.1.2*' }
+
+          it { is_expected.to compile.and_raise_error(%r(%\{EPOCH\}:%\{NAME\}-%\{VERSION\}-%\{RELEASE\}\.%\{ARCH\})) }
         end
       end
 
-      context 'and ensure set to absent' do
-        let(:params) { { ensure: 'absent' } }
-
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_concat__fragment('versionlock_header').with_content("# File managed by puppet\n") }
-
-        it 'contains a well-formed Concat::Fragment' do
-          is_expected.not_to contain_concat__fragment("yum-versionlock-#{title}")
+      context 'with a simple, well-formed package name title bash and a version' do
+        let(:facts) do
+          super().merge({ package_provider: 'yum' })
         end
-      end
 
-      context 'with version set namevar must be just a package name' do
+        let(:title) { 'bash' }
         let(:params) { { version: '4.3' } }
 
-        it { is_expected.to compile.and_raise_error(%r{Package name must be formatted as Yum::RpmName, not 'String'}) }
-      end
-    end
+        context 'with version set' do
+          it { is_expected.to compile.with_all_deps }
 
-    context 'with a trailing wildcard title' do
-      let(:title) { '0:bash-4.1.2-9.el6_2.*' }
+          it 'contains a well-formed Concat::Fragment' do
+            is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("0:bash-4.3-*.*\n")
+          end
+        end
 
-      it { is_expected.to compile.with_all_deps }
+        context 'with version, release, epoch and arch set' do
+          let(:params) do
+            {
+              version: '4.3',
+              release: '3.2',
+              arch: 'arm',
+              epoch: 42
+            }
+          end
 
-      it 'contains a well-formed Concat::Fragment' do
-        is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("#{title}\n")
-      end
-    end
+          context 'it works' do
+            it { is_expected.to compile.with_all_deps }
 
-    context 'with a complex wildcard title' do
-      let(:title) { '0:bash-4.*-*.el6' }
-
-      it 'contains a well-formed Concat::Fragment' do
-        is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("#{title}\n")
-      end
-    end
-
-    context 'with a release containing dots' do
-      let(:title) { '1:java-1.7.0-openjdk-1.7.0.121-2.6.8.0.el7_3.x86_64' }
-
-      it 'contains a well-formed Concat::Fragment' do
-        is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("#{title}\n")
-      end
-    end
-
-    context 'with an invalid title' do
-      let(:title) { 'bash-4.1.2' }
-
-      it { is_expected.to compile.and_raise_error(%r(%\{EPOCH\}:%\{NAME\}-%\{VERSION\}-%\{RELEASE\}\.%\{ARCH\})) }
-    end
-
-    context 'with an invalid wildcard pattern' do
-      let(:title) { '0:bash-4.1.2*' }
-
-      it { is_expected.to compile.and_raise_error(%r(%\{EPOCH\}:%\{NAME\}-%\{VERSION\}-%\{RELEASE\}\.%\{ARCH\})) }
-    end
-  end
-
-  context 'with a simple, well-formed package name title bash and a version' do
-    let(:facts) do
-      { os: { release: { major: 7 } },
-        package_provider: 'yum' }
-    end
-
-    let(:title) { 'bash' }
-    let(:params) { { version: '4.3' } }
-
-    context 'with version set' do
-      it { is_expected.to compile.with_all_deps }
-
-      it 'contains a well-formed Concat::Fragment' do
-        is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("0:bash-4.3-*.*\n")
-      end
-    end
-
-    context 'with version, release, epoch and arch set' do
-      let(:params) do
-        {
-          version: '4.3',
-          release: '3.2',
-          arch: 'arm',
-          epoch: 42
-        }
-      end
-
-      context 'it works' do
-        it { is_expected.to compile.with_all_deps }
-
-        it 'contains a well-formed Concat::Fragment' do
-          is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("42:bash-4.3-3.2.arm\n")
+            it 'contains a well-formed Concat::Fragment' do
+              is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("42:bash-4.3-3.2.arm\n")
+            end
+          end
         end
       end
-    end
-  end
 
-  context 'with package_provider set to dnf' do
-    let(:facts) do
-      { os: { release: { major: 8 } },
-        package_provider: 'dnf' }
-    end
+      context 'with package_provider set to dnf' do
+        let(:facts) do
+          super().merge({ package_provider: 'dnf' })
+        end
 
-    context 'with a simple, well-formed title, no version set' do
-      let(:title) { 'bash' }
+        context 'with a simple, well-formed title, no version set' do
+          let(:title) { 'bash' }
 
-      it { is_expected.to compile.and_raise_error(%r{Version must be formatted as Yum::RpmVersion}) }
+          it { is_expected.to compile.and_raise_error(%r{Version must be formatted as Yum::RpmVersion}) }
 
-      context 'and a version set to 4.3' do
+          context 'and a version set to 4.3' do
+            let(:params) { { version: '4.3' } }
+
+            it 'contains a well-formed Concat::Fragment' do
+              is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-0:4.3-*.*\n")
+            end
+
+            context 'and an arch set to x86_64' do
+              let(:params)  { super().merge(arch: 'x86_64') }
+
+              it 'contains a well-formed Concat::Fragment' do
+                is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-0:4.3-*.x86_64\n")
+              end
+            end
+
+            context 'and an release set to 22.x' do
+              let(:params) { super().merge(release: '22.5') }
+
+              it 'contains a well-formed Concat::Fragment' do
+                is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-0:4.3-22.5.*\n")
+              end
+            end
+
+            context 'and an epoch set to 5' do
+              let(:params) { super().merge(epoch: 5) }
+
+              it 'contains a well-formed Concat::Fragment' do
+                is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-5:4.3-*.*\n")
+              end
+            end
+          end
+
+          context 'with release, version, epoch, arch all set' do
+            let(:params) do
+              {
+                version: '22.5',
+                release: 'alpha12',
+                epoch: 8,
+                arch: 'i386'
+              }
+            end
+
+            it 'contains a well-formed Concat::Fragment' do
+              is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-8:22.5-alpha12.i386\n")
+            end
+          end
+        end
+      end
+
+      context 'with package_provider unset' do
+        let(:title) { 'bash' }
         let(:params) { { version: '4.3' } }
+
+        it { is_expected.to compile.with_all_deps }
 
         it 'contains a well-formed Concat::Fragment' do
           is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-0:4.3-*.*\n")
         end
-
-        context 'and an arch set to x86_64' do
-          let(:params)  { super().merge(arch: 'x86_64') }
-
-          it 'contains a well-formed Concat::Fragment' do
-            is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-0:4.3-*.x86_64\n")
-          end
-        end
-
-        context 'and an release set to 22.x' do
-          let(:params) { super().merge(release: '22.5') }
-
-          it 'contains a well-formed Concat::Fragment' do
-            is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-0:4.3-22.5.*\n")
-          end
-        end
-
-        context 'and an epoch set to 5' do
-          let(:params) { super().merge(epoch: 5) }
-
-          it 'contains a well-formed Concat::Fragment' do
-            is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-5:4.3-*.*\n")
-          end
-        end
       end
-
-      context 'with release, version, epoch, arch all set' do
-        let(:params) do
-          {
-            version: '22.5',
-            release: 'alpha12',
-            epoch: 8,
-            arch: 'i386'
-          }
-        end
-
-        it 'contains a well-formed Concat::Fragment' do
-          is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-8:22.5-alpha12.i386\n")
-        end
-      end
-    end
-  end
-
-  context 'with package_provider unset' do
-    let(:facts) do
-      { os: { release: { major: 7 } } }
-    end
-    let(:title) { 'bash' }
-    let(:params) { { version: '4.3' } }
-
-    it { is_expected.to compile.with_all_deps }
-
-    it 'contains a well-formed Concat::Fragment' do
-      is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-0:4.3-*.*\n")
     end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
In addition to https://github.com/voxpupuli/puppet-yum/pull/275
There is conditions where the sensitive information is displayed in the logs.  This add option to completely disable output in the logs.

```
class example {
  class { 'yum' :
    show_diff => false,
  }
}
```

#### Tests
I’m not a pro in the tests suite alley, feel free to comment on any other way I could have fixed the tests…  It took me way longer to fix the tests than to add the new config.

As the `yum::config` now `includes yum` to retreive `yum::show_diff`, the tests are done on every supported OS for the variables to be set correctly.

I had to modify the versionlock tests to make them pass.  The diff is quite hard to read, so here the summary of what I did:
- The tests are now run on every supported OS.
~~- I moved the context `'with a simple, well-formed package name title bash and a version'` in the context `'with package_provider set to yum'` as they were duplicated facts definition~~ edit: did not fix this in my new rebase
- I merge the fact `package_provider` with the facts provided by every OS
