### PR TITLE
Deploying multiple gpgkey in one repo

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -160,7 +160,8 @@ class yum (
                 if !defined(Yum::Gpgkey[$gpgkey]) {
                   yum::gpgkey { $gpgkey:
                     *      => $gpgkeys[$gpgkey],
-                    before => Package[$utils_package_name],  # GPG Keys for any managed repository need to be installed before we attempt to install any packages.
+                    before => Package[$utils_package_name],
+                    # GPG Keys for any managed repository need to be installed before we attempt to install any packages.
                   }
                 } # end if Yum::Gpgkey[$gpgkey] is not defined
               } # end if $gpgkey exists in gpgkeys

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -152,18 +152,20 @@ class yum (
         }
         # Handle GPG Key
         if ('gpgkey' in $attributes) {
-          $matches = $attributes['gpgkey'].match('^file://(.*)$')
-          if $matches {
-            $gpgkey = $matches[1]
-            if $gpgkey =~ Stdlib::AbsolutePath and $gpgkey in $gpgkeys {
-              if !defined(Yum::Gpgkey[$gpgkey]) {
-                yum::gpgkey { $gpgkey:
-                  *      => $gpgkeys[$gpgkey],
-                  before => Package[$utils_package_name],  # GPG Keys for any managed repository need to be installed before we attempt to install any packages.
-                }
-              } # end if Yum::Gpgkey[$gpgkey] is not defined
-            } # end if $gpgkey exists in gpgkeys
-          } # end if gpgkey is a file:// resource
+          $matches = $attributes['gpgkey'].split(/\s/).match('^file://(.*)$')
+          $matches.each |$match| {
+            if $match {
+              $gpgkey = $match[1]
+              if $gpgkey =~ Stdlib::AbsolutePath and $gpgkey in $gpgkeys {
+                if !defined(Yum::Gpgkey[$gpgkey]) {
+                  yum::gpgkey { $gpgkey:
+                    *      => $gpgkeys[$gpgkey],
+                    before => Package[$utils_package_name],  # GPG Keys for any managed repository need to be installed before we attempt to install any packages.
+                  }
+                } # end if Yum::Gpgkey[$gpgkey] is not defined
+              } # end if $gpgkey exists in gpgkeys
+            } # end if gpgkey is a file:// resource
+          } # end each matches
         } # end if $attributes has a gpgkey
       }
     }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -706,6 +706,58 @@ describe 'yum' do
         it { is_expected.not_to contain_package('yum-utils') }
         it { is_expected.to contain_package('dnf-utils') }
       end
+
+      context 'when custom repos is set' do
+        let(:params) do
+          {
+            managed_repos: ['example'],
+            repos: {
+              example: {
+                baseurl: 'https://example.com',
+                gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example'
+              }
+            },
+            gpgkeys: {
+              '/etc/pki/rpm-gpg/RPM-GPG-KEY-example' => {
+                'source' => 'http://example.com/gpg'
+              }
+            }
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to have_yumrepo_resource_count(1) }
+        it { is_expected.to contain_yumrepo('example') }
+        it { is_expected.to contain_yum__gpgkey('/etc/pki/rpm-gpg/RPM-GPG-KEY-example') }
+      end
+
+      context 'when custom repos with multiple gpgkeys is set' do
+        let(:params) do
+          {
+            managed_repos: ['example'],
+            repos: {
+              example: {
+                baseurl: 'https://example.com',
+                gpgkey: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example file:///etc/pki/rpm-gpg/RPM-GPG-KEY-example2',
+              }
+            },
+            gpgkeys: {
+              '/etc/pki/rpm-gpg/RPM-GPG-KEY-example' => {
+                'source' => 'http://example.com/gpg'
+              },
+              '/etc/pki/rpm-gpg/RPM-GPG-KEY-example2' => {
+                'source' => 'http://example.com/gpg2'
+              }
+            }
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to have_yumrepo_resource_count(1) }
+        it { is_expected.to contain_yumrepo('example') }
+        it { is_expected.to contain_yum__gpgkey('/etc/pki/rpm-gpg/RPM-GPG-KEY-example') }
+        it { is_expected.to contain_yum__gpgkey('/etc/pki/rpm-gpg/RPM-GPG-KEY-example2') }
+      end
     end
   end
 


### PR DESCRIPTION
#### Pull Request (PR) description
The yum repository format should support entering multiple keys in the `gpgkey` entry, like the following entry for gitlab:
```
[gitlab_gitlab-ce]
name=gitlab_gitlab-ce
baseurl=https://packages.gitlab.com/gitlab/gitlab-ce/el/8/$basearch
repo_gpgcheck=1
gpgcheck=1
enabled=1
gpgkey=https://packages.gitlab.com/gitlab/gitlab-ce/gpgkey
       https://packages.gitlab.com/gitlab/gitlab-ce/gpgkey/gitlab-gitlab-ce-3D645A26AB9FBD22.pub.gpg
sslverify=1
sslcacert=/etc/pki/tls/certs/ca-bundle.crt
metadata_expire=300
```
Currently, this module only deploy the first gpgkey it encounter.  This change allow to deploy multiples gpg keys (separated by any white spaces), for example:
```
class { 'yum' :
  managed_repos => ['gitlab'],
  gpgkeys       => {
    '/etc/pki/rpm-gpg/RPM-GPG-KEY-gitlab'                  => { source => 'https://packages.gitlab.com/gitlab/gitlab-ce/gpgkey' },
    '/etc/pki/rpm-gpg/RPM-GPG-KEY-gitlab-3D645A26AB9FBD22' => { source => 'https://packages.gitlab.com/gitlab/gitlab-ce/gpgkey/gitlab-gitlab-ce-3D645A26AB9FBD22.pub.gpg' },
  },
  repos         => {
    'gitlab' => {
      [...]
      'gpgkey' => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-gitlab file:///etc/pki/rpm-gpg/RPM-GPG-KEY-gitlab-3D645A26AB9FBD22',
    },
}
```