### PR TITLE
README: remove yumrepo.target in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ yum::repos:
         baseurl: 'https://repos.example.com/example/'
         gpgcheck: true
         gpgkey: 'file:///etc/pki/gpm-gpg/RPM-GPG-KEY-Example'
-        target: '/etc/yum.repos.d/example.repo'
 ```
 
 You can include gpgkeys in yaml as well, and if the key filename matches a


### PR DESCRIPTION
The `target` parameter is not implemented yet, so it doesn't do anything, and the yumrepo docs say not to use it: https://github.com/puppetlabs/puppetlabs-yumrepo_core/blob/136ee930eda907171a76fd599846f62602bec685/REFERENCE.md?plain=1#L349

See also: https://github.com/puppetlabs/puppetlabs-yumrepo_core/pull/47