### PR TITLE
Revert #258, which added purge_unmanaged_repos

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,12 +55,6 @@
 # @param utils_package_name
 #   Name of the utils package, e.g. 'yum-utils', or 'dnf-utils'.
 #
-# @param purge_unmanaged_repos
-#   Should repos not managed by puppet be removed?
-#
-# @param repodir
-#   Where are repos stored on this system?
-#
 # @example Enable management of the default repos for a supported OS:
 #   ---
 #   yum::manage_os_default_repos: true
@@ -111,25 +105,11 @@ class yum (
   Array[String] $repo_exclusions = [],
   Hash[String, Hash[String, String]] $gpgkeys = {},
   String $utils_package_name = 'yum-utils',
-  Boolean $purge_unmanaged_repos = false,
-  Stdlib::Unixpath $repodir = '/etc/yum.repos.d',
 ) {
   $module_metadata            = load_module_metadata($module_name)
   $supported_operatingsystems = $module_metadata['operatingsystem_support']
   $supported_os_names         = $supported_operatingsystems.map |$os| {
     $os['operatingsystem']
-  }
-
-  if $purge_unmanaged_repos {
-    file { $repodir:
-      ensure       => 'directory',
-      owner        => 'root',
-      group        => 'root',
-      mode         => '0644',
-      recurse      => true,
-      recurselimit => 1,
-      purge        => true,
-    }
   }
 
   unless member($supported_os_names, $facts['os']['name']) {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -618,10 +618,9 @@ describe 'yum' do
         end
 
         context 'to an array of all supported repos' do
-          let(:params) { { managed_repos: supported_repos, purge_unmanaged_repos: true } }
+          let(:params) { { managed_repos: supported_repos } }
 
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_file('/etc/yum.repos.d').with_purge(true) }
           it { is_expected.to have_yumrepo_resource_count(supported_repos.count) }
 
           it_behaves_like 'a catalog containing repos', supported_repos


### PR DESCRIPTION
This method of purging unmanaged yum repo configs does not work. This is because the repo configs are managed by puppetlabs/yumrepo_core as native `yumrepo` types, not `file` resources.

Fixes #285