### PR TITLE
Use dnf or yum augeas path for main configuration

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -10,6 +10,7 @@
 * [`yum::clean`](#yum--clean): A $(yum clean all) Exec to be notified if desired.
 * [`yum::plugin::post_transaction_actions`](#yum--plugin--post_transaction_actions): Class to install post_transaction plugin
 * [`yum::plugin::versionlock`](#yum--plugin--versionlock): This class installs versionlock plugin
+* [`yum::settings`](#yum--settings): Simple settings to use
 
 ### Defined types
 
@@ -298,6 +299,24 @@ Default value: `false`
 Data type: `String`
 
 filepath for the versionlock.list, default based on your system.
+
+### <a name="yum--settings"></a>`yum::settings`
+
+Simple settings to use
+
+#### Parameters
+
+The following parameters are available in the `yum::settings` class:
+
+* [`mainconf`](#-yum--settings--mainconf)
+
+##### <a name="-yum--settings--mainconf"></a>`mainconf`
+
+Data type: `Enum['/etc/yum.conf','/etc/dnf/dnf.conf']`
+
+Augeas location of the dnf or yum configuration file.
+The default is set into hiera according to the package_provider
+being yum or dnf.
 
 ## Defined types
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -20,3 +20,4 @@ lookup_options:
 
 # Default is currently yum path
 yum::plugin::versionlock::path: /etc/yum/pluginconf.d/versionlock.list
+yum::settings::mainconf: /etc/yum.conf

--- a/data/package_provider/dnf.yaml
+++ b/data/package_provider/dnf.yaml
@@ -1,2 +1,3 @@
 ---
 yum::plugin::versionlock::path: /etc/dnf/plugins/versionlock.list
+yum::settings::mainconf:        /etc/dnf/dnf.conf

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,6 +18,9 @@ define yum::config (
   Variant[Boolean, Integer, Enum['absent'], String, Sensitive[String]] $ensure,
   String                                            $key     = $title,
 ) {
+  include yum::settings
+  $_mainconf = $yum::settings::mainconf
+
   $_ensure = $ensure ? {
     Boolean   => bool2num($ensure),
     Sensitive => $ensure.unwrap,
@@ -34,10 +37,10 @@ define yum::config (
     default   => true,
   }
 
-  augeas { "yum.conf_${key}":
-    incl      => '/etc/yum.conf',
+  augeas { "${facts['package_provider']}.conf_${key}":
+    incl      => $_mainconf,
     lens      => 'Yum.lns',
-    context   => '/files/etc/yum.conf/main/',
+    context   => "/files${_mainconf}/main/",
     changes   => $_changes,
     show_diff => $_show_diff,
   }

--- a/manifests/settings.pp
+++ b/manifests/settings.pp
@@ -1,0 +1,9 @@
+# @summary Simple settings to use
+# @param mainconf
+#   Augeas location of the dnf or yum configuration file.
+#   The default is set into hiera according to the package_provider
+#   being yum or dnf.
+#
+class yum::settings (
+  Enum['/etc/yum.conf','/etc/dnf/dnf.conf'] $mainconf,
+) {}

--- a/spec/acceptance/define_versionlock_spec.rb
+++ b/spec/acceptance/define_versionlock_spec.rb
@@ -44,14 +44,17 @@ describe 'yum::versionlock define' do
       apply_manifest(pp, catch_changes:  true)
     end
 
-    describe file('/etc/yum/pluginconf.d/versionlock.list') do
-      it { is_expected.to be_file }
-
-      if %w[7].include?(fact('os.release.major'))
+    if fact('os.release.major') == '7'
+      describe file('/etc/yum/pluginconf.d/versionlock.list') do
+        it { is_expected.to be_file }
         it { is_expected.to contain '0:bash-4.1.2-9.el6_2.*' }
         it { is_expected.to contain '0:tcsh-3.1.2-9.el6_2.*' }
         it { is_expected.to contain '2:netscape-8.1.2-9.el6_2.*' }
-      else
+      end
+    else
+      describe file('/etc/dnf/plugins/versionlock.list') do
+        it { is_expected.to be_file }
+
         it { is_expected.to contain 'bash-0:4.1.2-9.el6_2.*' }
         it { is_expected.to contain 'tcsh-0:3.1.2-9.el6_2.*' }
         it { is_expected.to contain 'netscape-2:8.1.2-9.el6_2.*' }

--- a/spec/acceptance/yum_config_variable_false_spec.rb
+++ b/spec/acceptance/yum_config_variable_false_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+describe 'yum::config variable false' do
+  context 'simple parameters' do
+    # Using puppet_apply as a helper
+    it 'must work idempotently with no errors' do
+      pp = <<-EOS
+      yum::config{'variable':
+        ensure   => false,
+      }
+      EOS
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes:  true)
+    end
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description

Currently the augeas path for main configuration is at `/files/etc/yum.conf/main`.

Use a dnf or yum based path based on the package_provider fact.

On Fedora 36 and newer that hard coded augeas path does not exist:

```
[steve@fedora ~]$ augtool -e 'print /files/etc/yum.conf/main'
augtool> print /files/etc/yum.conf/main
```

only the new updated dnf based path exists.

```
augtool> print /files/etc/dnf/dnf.conf
/files/etc/dnf/dnf.conf
/files/etc/dnf/dnf.conf/#comment = "see `man dnf.conf` for defaults and possible options"
/files/etc/dnf/dnf.conf/main
/files/etc/dnf/dnf.conf/main/gpgcheck = "True"
/files/etc/dnf/dnf.conf/main/installonly_limit = "3"
/files/etc/dnf/dnf.conf/main/clean_requirements_on_remove = "True"
/files/etc/dnf/dnf.conf/main/best = "False"
/files/etc/dnf/dnf.conf/main/skip_if_unavailable = "True"
```

Note on EL8 and EL9 both paths `/files/etc/yum.conf` and `/files/etc/dnf.conf`  are valid and equal.

Consequently on puppet runs `yum::init` sets the `installonly_limit` to 3 in the wrong non-existing file.

To solve this create a new file yum::settings that can have values set from hiera for the `yum::config` type. The more obvious use of setting this in `init.pp` is not possible since including this in `yum::config` would be a huge change for the module.

Note that when the install_limit is changed to 3 the following command is called

`/usr/bin/package-cleanup --oldkernels --count=3 -y` 

and this is bug #295 . This patch hides that problem in acceptance tests again.
