### PR TITLE
Fix acceptance tests for Fedora 36

### DIFF
--- a/spec/acceptance/define_versionlock_spec.rb
+++ b/spec/acceptance/define_versionlock_spec.rb
@@ -61,12 +61,12 @@ describe 'yum::versionlock define' do
       end
     end
 
-    if fact('os.release.major') >= '8'
-      describe package('python3-dnf-plugin-versionlock') do
+    if fact('os.release.major') == '7'
+      describe package('yum-plugin-versionlock') do
         it { is_expected.to be_installed }
       end
     else
-      describe package('yum-plugin-versionlock') do
+      describe package('python3-dnf-plugin-versionlock') do
         it { is_expected.to be_installed }
       end
     end
@@ -101,8 +101,10 @@ describe 'yum::versionlock define' do
     if fact('os.release.major') == '7'
       shell('yum -C repolist -d0 | grep -v "repo id"  | awk "{print $NF}" FS=  | grep -v 0', acceptable_exit_codes: [1])
       shell('yum -q list available samba-devel', acceptable_exit_codes: [1])
-    else
+    elsif %w[8 9].include?(fact('os.release.major'))
       shell('dnf -q list --available samba-devel', acceptable_exit_codes: [1])
+    else
+      shell('dnf install -y samba-devel | grep "All matches were filtered"', acceptable_exit_codes: [0])
     end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description

With new versions of DNF

```
dnf -q list --available samba-devel
```
still shows samba-devel as available even when a non matching  versionlock exists. This looks to be by design.

Attempting to and failing to install the package is better validation anyway.

* https://bugzilla.redhat.com/show_bug.cgi?id=1746562#c1