### PR TITLE
Fix purge of unwanted kernels on DNF based machines

### DIFF
--- a/spec/acceptance/yum_config_install_limit_2_spec.rb
+++ b/spec/acceptance/yum_config_install_limit_2_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+describe 'yum::config installonly_limit 1' do
+  context 'simple parameters' do
+    # Using puppet_apply as a helper
+    it 'must work idempotently with no errors' do
+      pp = <<-EOS
+      yum::config{'installonly_limit':
+        ensure   => 2,   # yum (and not dnf) does not like the value 1
+      }
+      include yum
+      EOS
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes:  true)
+    end
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description

Previously when `installonly_limit` of a node is adjusted then `package-cleanup` was called to remove unwanted old kernels. This is invalid for dnf based systems and a new command must be used.

This DNF command will remove kernel packages except in two cases:
* It is the running kernel as determined from `$facts['kernelrelease']`
* It is one of last N kernel versions where N is the `installonly_limit`

#### This Pull Request (PR) fixes the following issues
Fixes #295

