### PR TITLE
New yum::groups parameter to manage groups

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -101,6 +101,17 @@ yum::repos:
         mirrorlist: '--'
 ```
 
+##### Install a couple of `yum::group`s.
+
+```puppet
+---
+yum::groups:
+  'Development Tools':
+    ensure: present
+  'System Tools':
+    ensure: present
+```
+
 #### Parameters
 
 The following parameters are available in the `yum` class:
@@ -115,6 +126,7 @@ The following parameters are available in the `yum` class:
 * [`repo_exclusions`](#-yum--repo_exclusions)
 * [`gpgkeys`](#-yum--gpgkeys)
 * [`utils_package_name`](#-yum--utils_package_name)
+* [`groups`](#-yum--groups)
 
 ##### <a name="-yum--clean_old_kernels"></a>`clean_old_kernels`
 
@@ -219,6 +231,14 @@ Data type: `String`
 Name of the utils package, e.g. 'yum-utils', or 'dnf-utils'.
 
 Default value: `'yum-utils'`
+
+##### <a name="-yum--groups"></a>`groups`
+
+Data type: `Stdlib::CreateResources`
+
+A hash of yum::group instances to manage.
+
+Default value: `{}`
 
 ### <a name="yum--clean"></a>`yum::clean`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,6 +55,9 @@
 # @param utils_package_name
 #   Name of the utils package, e.g. 'yum-utils', or 'dnf-utils'.
 #
+# @param groups
+#   A hash of yum::group instances to manage.
+#
 # @example Enable management of the default repos for a supported OS:
 #   ---
 #   yum::manage_os_default_repos: true
@@ -94,6 +97,14 @@
 #           baseurl: 'https://repos.example.com/CentOS/base/'
 #           mirrorlist: '--'
 #
+# @example Install a couple of `yum::group`s.
+#   ---
+#   yum::groups:
+#     'Development Tools':
+#       ensure: present
+#     'System Tools':
+#       ensure: present
+#
 class yum (
   Boolean $clean_old_kernels = true,
   Boolean $keep_kernel_devel = false,
@@ -105,6 +116,7 @@ class yum (
   Array[String] $repo_exclusions = [],
   Hash[String, Hash[String, String]] $gpgkeys = {},
   String $utils_package_name = 'yum-utils',
+  Stdlib::CreateResources $groups = {}
 ) {
   $module_metadata            = load_module_metadata($module_name)
   $supported_operatingsystems = $module_metadata['operatingsystem_support']
@@ -221,5 +233,11 @@ class yum (
     refreshonly => true,
     require     => Package[$utils_package_name],
     subscribe   => $_clean_old_kernels_subscribe,
+  }
+
+  $groups.each |$_group, $_group_attrs| {
+    yum::group { $_group:
+      * => $_group_attrs,
+    }
   }
 }

--- a/spec/acceptance/define_group_spec.rb
+++ b/spec/acceptance/define_group_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+describe 'managing a yum::group' do
+  context 'installing group RPM dev tools' do
+    # Using puppet_apply as a helper
+    it 'must work idempotently with no errors' do
+      pp = <<-EOS
+      yum::group { 'Development Tools':
+        ensure => 'installed',
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes:  true)
+    end
+
+    # On stupid 7 test package has to be leaf package
+    # to be removed with a "groupremove". Can't find
+    # a common package that works.
+    case fact('os.release.major')
+    when '7'
+      describe package('libtool') do
+        it { is_expected.to be_installed }
+      end
+    else
+      describe package('make') do
+        it { is_expected.to be_installed }
+      end
+    end
+  end
+
+  context 'removing group RPM dev tools' do
+    # Using puppet_apply as a helper
+    it 'must work idempotently with no errors' do
+      pp = <<-EOS
+      yum::group { 'Development Tools':
+        ensure => 'absent',
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes:  true)
+    end
+
+    case fact('os.release.major')
+    when '7'
+      describe package('libtool') do
+        it { is_expected.not_to be_installed }
+      end
+    else
+      describe package('make') do
+        it { is_expected.not_to be_installed }
+      end
+    end
+  end
+end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -43,6 +43,7 @@ describe 'yum' do
 
         it_behaves_like 'a Yum class'
         it { is_expected.to have_yumrepo_resource_count(0) }
+        it { is_expected.to have_yum__group_resource_count(0) }
       end
 
       context 'when `manage_os_default_repos` is enabled' do
@@ -796,6 +797,24 @@ describe 'yum' do
         it { is_expected.to contain_yumrepo('example') }
         it { is_expected.to contain_yum__gpgkey('/etc/pki/rpm-gpg/RPM-GPG-KEY-example') }
         it { is_expected.to contain_yum__gpgkey('/etc/pki/rpm-gpg/RPM-GPG-KEY-example2') }
+      end
+
+      context 'when groups parameter is set' do
+        let(:params) do
+          {
+            groups: {
+              'Dev Tools': {
+                ensure: 'installed',
+              },
+              'Puppet Tools': {
+                ensure: 'absent',
+              },
+            },
+          }
+        end
+
+        it { is_expected.to contain_yum__group('Puppet Tools').with_ensure('absent') }
+        it { is_expected.to contain_yum__group('Dev Tools').with_ensure('installed') }
       end
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description

A hash of Yum groups can now be managed easily from hiera:

```yaml
---
yum::groups:
   'Puppet Dev':
      ensure: installed
   'Rpm Dev':
      ensure: absent
```

the existing `yum::group` defined type is used.

#### This Pull Request (PR) fixes the following issues
Fixes #305

