### PR TITLE
[WIP] [Issue 310] Enable DNF modules management

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,46 @@ class { 'yum':
 }
 ```
 
+### Manage DNF modules
+
+#### Enable nginx module default stream
+
+```puppet
+dnf_module { 'module_nginx_stream_1.20':
+  module         => 'nginx',
+  enabled_stream => true,
+}
+```
+
+#### Install default profile from nginx module '1.20' stream
+
+```puppet
+dnf_module { 'module_nginx_stream_1.20':
+  module             => 'nginx',
+  enabled_stream     => '1.20',
+  installed_profiles => true,
+}
+```
+
+#### Install 'minimal' and 'devel' profiles from php module current stream
+
+```puppet
+dnf_module { 'module_nginx_stream_1.20':
+  module             => 'php',
+  installed_profiles => ['minimal', 'devel'],
+}
+```
+
+#### Uninstall all profiles from php module current stream
+
+```puppet
+dnf_module { 'module_nginx_stream_1.20':
+  module             => 'php',
+  installed_profiles => [],
+  removed_profiles   => true,
+}
+```
+
 ### Add/remove a GPG RPM signing key using an inline key block
 
 ```puppet

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1040,6 +1040,43 @@ Manages DNF modules
 
 [Read the Docs - DNF - Modularity](https://dnf.readthedocs.io/en/latest/modularity.html)
 
+#### Parameters
+
+- [`module`](#-yum--module)
+- [`enabled_stream`](#-yum--enabled_stream)
+- [`installed_profiles`](#-yum--installed_profiles)
+- [`removed_profiles`](#-yum--removed_profiles)
+
+##### <a name="-yum--module"></a>`module`
+
+Data type: `String`
+
+DNF module to manage. Fails if module doesn't exist.
+
+##### <a name="-yum--enabled_stream"></a>`enabled_stream`
+
+Data type: `Variant[String, Boolean, Undef]`
+
+DNF module stream to enable. Keep current state if `Undef`, enable default stream if `true`, reset (disable any stream) if `false`. Fails if stream doesn't exist.
+
+Default value: `Undef`
+
+##### <a name="-yum--installed_profiles"></a>`installed_profiles`
+
+Data type: `Variant[String, Array[String], Boolean[true], Undef]`
+
+DNF module profile(s) to install. Keep current state if `Undef` or `[]`, install default profile if `true`. Fails if any profile doesn't exist.
+
+Default value: `[]`
+
+##### <a name="-yum--removed_profiles"></a>`removed_profiles`
+
+Data type: `Variant[String, Array[String], Boolean[true], Undef]`
+
+DNF module profile(s) to uninstall. Keep current state if `Undef` or `[]`, uninstall all profile(s) not specified in [`installed_profiles`](#-yum--installed_profiles) if `true`. Fails if any profile doesn't exist or is also listed in [`installed_profiles`](#-yum--installed_profiles).
+
+Default value: `[]`
+
 ## Tasks
 
 ### <a name="init"></a>`init`

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1040,6 +1040,46 @@ Manages DNF modules
 
 [Read the Docs - DNF - Modularity](https://dnf.readthedocs.io/en/latest/modularity.html)
 
+#### Examples
+
+##### Enable nginx module default stream
+
+```puppet
+dnf_module { 'module_nginx_stream_1.20':
+  module         => 'nginx',
+  enabled_stream => true,
+}
+```
+
+##### Install default profile from nginx module '1.20' stream
+
+```puppet
+dnf_module { 'module_nginx_stream_1.20':
+  module             => 'nginx',
+  enabled_stream     => '1.20',
+  installed_profiles => true,
+}
+```
+
+##### Install 'minimal' and 'devel' profiles from php module current stream
+
+```puppet
+dnf_module { 'module_nginx_stream_1.20':
+  module             => 'php',
+  installed_profiles => ['minimal', 'devel'],
+}
+```
+
+##### Uninstall all profiles from php module current stream
+
+```puppet
+dnf_module { 'module_nginx_stream_1.20':
+  module             => 'php',
+  installed_profiles => [],
+  removed_profiles   => true,
+}
+```
+
 #### Parameters
 
 - [`module`](#-yum--module)

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -36,6 +36,10 @@
 * [`Yum::RpmVersion`](#Yum--RpmVersion): Valid rpm version fields.
 * [`Yum::VersionlockString`](#Yum--VersionlockString): This type matches strings appropriate for use with yum-versionlock. Its basic format, using the `rpm(8)` query string format, is `%{EPOCH}:%{
 
+### Custom types
+
+* [`dnf_module`](#dnf_module): This custom type manages DNF modules
+
 ### Tasks
 
 * [`init`](#init): Allows you to perform yum functions
@@ -1023,6 +1027,14 @@ lint:ignore:140chars
 ```
 
 Alias of `Pattern[/^([0-9\*]+):([0-9a-zA-Z\._\+%\{\}\*-]+)-([^-]+)-([^-]+)\.(([0-9a-zZ-Z_\*]+)(?:\.(noarch|x86_64|i386|arm|ppc64|ppc64le|sparc64|ia64|alpha|ip|m68k|mips|mipsel|mk68k|mint|ppc|rs6000|s390|s390x|sh|sparc|xtensa|\*))?)$/]`
+
+## Custom types
+
+### <a name="dnf_module"></a>`dnf_module`
+
+Manages DNF modules
+
+> Only works in Linux distros which use DNF as package manager, like RHEL/Rocky >= 8
 
 ## Tasks
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1036,6 +1036,10 @@ Manages DNF modules
 
 > Only works in Linux distros which use DNF as package manager, like RHEL/Rocky >= 8
 
+#### See also
+
+[Read the Docs - DNF - Modularity](https://dnf.readthedocs.io/en/latest/modularity.html)
+
 ## Tasks
 
 ### <a name="init"></a>`init`

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -23,6 +23,10 @@
 * [`yum::post_transaction_action`](#yum--post_transaction_action): Creates post transaction configuratons for dnf or yum.
 * [`yum::versionlock`](#yum--versionlock): Locks package from updates.
 
+### Resource types
+
+* [`dnf_module`](#dnf_module): Manage DNF modules
+
 ### Functions
 
 * [`yum::bool2num_hash_recursive`](#yum--bool2num_hash_recursive): This functions converts the Boolean values of a Hash to Integers, either '0' or '1'.  It does this recursively, decending as far as the langu
@@ -35,10 +39,6 @@
 * [`Yum::RpmRelease`](#Yum--RpmRelease): Valid rpm release fields.
 * [`Yum::RpmVersion`](#Yum--RpmVersion): Valid rpm version fields.
 * [`Yum::VersionlockString`](#Yum--VersionlockString): This type matches strings appropriate for use with yum-versionlock. Its basic format, using the `rpm(8)` query string format, is `%{EPOCH}:%{
-
-### Custom types
-
-* [`dnf_module`](#dnf_module): This custom type manages DNF modules
 
 ### Tasks
 
@@ -829,6 +829,74 @@ Epoch of the package if CentOS 8 mechanism is used.
 
 Default value: `0`
 
+## Resource types
+
+### <a name="dnf_module"></a>`dnf_module`
+
+This type allows Puppet to enable/disable streams and install/remove profiles via DNF modules
+
+#### Examples
+
+##### Install MariaDB 10.5 Galera profile
+
+```puppet
+dnf_module { 'mariadb_galera_10.5':
+  module             => 'mariadb',
+  enabled_stream     => '10.5',
+  installed_profiles => 'galera',
+  removed_profiles   => true,
+}
+```
+
+#### Properties
+
+The following properties are available in the `dnf_module` type.
+
+##### `enabled_stream`
+
+      Module stream that should be enabled
+String - Specify stream
+true - Default stream
+false - No stream (resets module)
+nil (default) - Keep current
+
+##### `installed_profiles`
+
+      Module profile(s) that should be installed
+String or Array - Specify profile(s)
+true - Default profile
+
+Default value: `[]`
+
+##### `removed_profiles`
+
+      Module profile(s) that should be removed
+String or Array - Specify profile(s)
+true - All not listed in installed_profiles
+
+Default value: `[]`
+
+#### Parameters
+
+The following parameters are available in the `dnf_module` type.
+
+* [`module`](#-dnf_module--module)
+* [`provider`](#-dnf_module--provider)
+* [`title`](#-dnf_module--title)
+
+##### <a name="-dnf_module--module"></a>`module`
+
+Module to be managed (String)
+
+##### <a name="-dnf_module--provider"></a>`provider`
+
+The specific backend to use for this `dnf_module` resource. You will seldom need to specify this --- Puppet will usually
+discover the appropriate provider for your platform.
+
+##### <a name="-dnf_module--title"></a>`title`
+
+Resource title
+
 ## Functions
 
 ### <a name="yum--bool2num_hash_recursive"></a>`yum::bool2num_hash_recursive`
@@ -1027,95 +1095,6 @@ lint:ignore:140chars
 ```
 
 Alias of `Pattern[/^([0-9\*]+):([0-9a-zA-Z\._\+%\{\}\*-]+)-([^-]+)-([^-]+)\.(([0-9a-zZ-Z_\*]+)(?:\.(noarch|x86_64|i386|arm|ppc64|ppc64le|sparc64|ia64|alpha|ip|m68k|mips|mipsel|mk68k|mint|ppc|rs6000|s390|s390x|sh|sparc|xtensa|\*))?)$/]`
-
-## Custom types
-
-### <a name="dnf_module"></a>`dnf_module`
-
-Manages DNF modules
-
-> Only works in Linux distros which use DNF as package manager, like RHEL/Rocky >= 8
-
-#### See also
-
-[Read the Docs - DNF - Modularity](https://dnf.readthedocs.io/en/latest/modularity.html)
-
-#### Examples
-
-##### Enable nginx module default stream
-
-```puppet
-dnf_module { 'module_nginx_stream_1.20':
-  module         => 'nginx',
-  enabled_stream => true,
-}
-```
-
-##### Install default profile from nginx module '1.20' stream
-
-```puppet
-dnf_module { 'module_nginx_stream_1.20':
-  module             => 'nginx',
-  enabled_stream     => '1.20',
-  installed_profiles => true,
-}
-```
-
-##### Install 'minimal' and 'devel' profiles from php module current stream
-
-```puppet
-dnf_module { 'module_nginx_stream_1.20':
-  module             => 'php',
-  installed_profiles => ['minimal', 'devel'],
-}
-```
-
-##### Uninstall all profiles from php module current stream
-
-```puppet
-dnf_module { 'module_nginx_stream_1.20':
-  module             => 'php',
-  installed_profiles => [],
-  removed_profiles   => true,
-}
-```
-
-#### Parameters
-
-- [`module`](#-yum--module)
-- [`enabled_stream`](#-yum--enabled_stream)
-- [`installed_profiles`](#-yum--installed_profiles)
-- [`removed_profiles`](#-yum--removed_profiles)
-
-##### <a name="-yum--module"></a>`module`
-
-Data type: `String`
-
-DNF module to manage. Fails if module doesn't exist.
-
-##### <a name="-yum--enabled_stream"></a>`enabled_stream`
-
-Data type: `Variant[String, Boolean, Undef]`
-
-DNF module stream to enable. Keep current state if `Undef`, enable default stream if `true`, reset (disable any stream) if `false`. Fails if stream doesn't exist.
-
-Default value: `Undef`
-
-##### <a name="-yum--installed_profiles"></a>`installed_profiles`
-
-Data type: `Variant[String, Array[String], Boolean[true], Undef]`
-
-DNF module profile(s) to install. Keep current state if `Undef` or `[]`, install default profile if `true`. Fails if any profile doesn't exist.
-
-Default value: `[]`
-
-##### <a name="-yum--removed_profiles"></a>`removed_profiles`
-
-Data type: `Variant[String, Array[String], Boolean[true], Undef]`
-
-DNF module profile(s) to uninstall. Keep current state if `Undef` or `[]`, uninstall all profile(s) not specified in [`installed_profiles`](#-yum--installed_profiles) if `true`. Fails if any profile doesn't exist or is also listed in [`installed_profiles`](#-yum--installed_profiles).
-
-Default value: `[]`
 
 ## Tasks
 

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -3,6 +3,8 @@
 Puppet::Type.type(:dnf_module).provide(:dnf_module) do
   desc 'Unique provider'
 
+  confine package_provider: 'dnf'
+
   commands dnf: 'dnf'
 
   # Converts plain output from 'dnf module list <Module>' to an array formatted as:

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -42,6 +42,7 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
     return false unless @module_state.key?(:enabled_stream)
     return true if resource[:enabled_stream] == true and
       @module_state[:enabled_stream] == @module_state[:default_stream]
+    @module_state[:enabled_stream]
   end
 
   def enabled_stream=(stream)

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -153,4 +153,12 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
       set_module_state(install.map{ |profile| "#{resource[:module]}/#{profile}"}.join(' '), 'install')
     end
   end
+
+  def removed_profiles
+    nil
+  end
+
+  def removed_profiles=(profiles)
+    nil
+  end
 end

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -2,4 +2,12 @@
 
 Puppet::Type.type(:dnf_module).provide(:dnf_module) do
   desc 'Unique provider'
+
+  def enabled_stream
+    nil
+  end
+
+  def enabled_stream=(stream)
+    nil
+  end
 end

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -177,6 +177,6 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
   end
 
   def removed_profiles=(profiles)
-    nil
+    dnf('-y', 'module', 'remove', @profiles_to_remove.map{ |profile| "#{resource[:module]}/#{profile}"}.join(' '))
   end
 end

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -6,10 +6,18 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
   commands dnf: 'dnf'
 
   def dnf_output_2_hash(dnf_output)
-    module_hash = {}
+    module_hash = {streams: {}}
     dnf_output.lines.each do |line|
       line.chomp!
       break if line.empty?
+      if ! @stream_start.nil?
+        stream_string = line[@stream_start, @stream_length].rstrip
+        stream = stream_string.split[0]
+        module_hash[:streams][stream] = {}
+      elsif line.split[0] == 'Name'
+        @stream_start = line[/Name\s+/].length
+        @stream_length = line[/Stream\s+/].length
+      end
     end
     module_hash
   end

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Puppet::Type.type(:dnf_module).provide(:dnf_module) do
+  desc 'Unique provider'
+end

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -34,6 +34,10 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
 
   def enabled_stream
     get_module_state(resource[:module])
+    raise ArgumentError, "No enabled stream to keep in module \"#{resource[:module]}\"" if
+      resource[:enabled_stream].nil? and ! @module_state.key?(:enabled_stream)
+    raise ArgumentError, "No default stream to enable in module \"#{resource[:module]}\"" if
+      resource[:enabled_stream] == true and ! @module_state.key?(:default_stream)
   end
 
   def enabled_stream=(stream)

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -13,6 +13,8 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
       if ! @stream_start.nil?
         stream_string = line[@stream_start, @stream_length].rstrip
         stream = stream_string.split[0]
+        module_hash[:default_stream] = stream if stream_string.include?('[d]')
+        module_hash[:enabled_stream] = stream if stream_string.include?('[e]')
         module_hash[:streams][stream] = {}
       elsif line.split[0] == 'Name'
         @stream_start = line[/Name\s+/].length

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -155,7 +155,11 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
   end
 
   def removed_profiles
-    nil
+    get_module_state(resource[:module])
+    stream_contents = @module_state[:streams][@profiles_stream]
+    # Profiles exist inside stream
+    raise ArgumentError, "No enabled or default stream in module \"#{resource[:module]}\"" if
+      @profiles_stream.nil?
   end
 
   def removed_profiles=(profiles)

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -68,6 +68,11 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
 
   def installed_profiles
     get_module_state(resource[:module])
+    stream = @module_state[:enabled_stream] || @module_state[:default_stream]
+    if stream.nil?
+      return [] if resource[:installed_profiles].empty?
+      raise ArgumentError, "No enabled or default stream in module \"#{resource[:module]}\""
+    end
   end
 
   def installed_profiles=(profiles)

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -34,6 +34,7 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
   end
 
   def get_module_state(module_name)
+    return unless @module_state.nil?
     dnf_output = dnf('-q', 'module', 'list', module_name)
   rescue Puppet::ExecutionFailure
     raise ArgumentError, "Module \"#{module_name}\" not found"
@@ -63,5 +64,13 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
     else
       dnf('-y', 'module', 'switch-to', "#{resource[:module]}:#{stream}")
     end
+  end
+
+  def installed_profiles
+    get_module_state(resource[:module])
+  end
+
+  def installed_profiles=(profiles)
+    nil
   end
 end

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -5,12 +5,30 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
 
   commands dnf: 'dnf'
 
+  # Converts plain output from 'dnf module list <Module>' to an array formatted as:
+  # {
+  #   default_stream: "<Default stream> (if there's one)",
+  #   enabled_stream: "<Enabled stream> (if there's one)",
+  #   streams: {
+  #     "<Stream>" => {
+  #       profiles: [<All available profiles for the stream>],
+  #       default_profile: "<Default profile> (if there's one)",
+  #       installed_profiles: [<All currently installed profiles>],
+  #     }
+  #   },
+  #   "<Stream>" => {...},
+  #   ...,
+  # }
   def dnf_output_2_hash(dnf_output)
     module_hash = {streams: {}}
     dnf_output.lines.each do |line|
       line.chomp!
       break if line.empty?
+      # @stream_start, @stream_length, @profiles_start and @profiles_length:
+      # chunk of dnf output line with stream or profile info
+      # Determined in elsif block below from dnf output header
       if ! @stream_start.nil?
+        # Stream string is '<Stream>', '<Stream> [d][e]', or the like
         stream_string = line[@stream_start, @stream_length].rstrip
         stream = stream_string.split[0]
         module_hash[:default_stream] = stream if stream_string.include?('[d]')
@@ -18,12 +36,15 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
         module_hash[:streams][stream] = {profiles: [], installed_profiles: []}
         profiles_string = line[@profiles_start, @profiles_length].rstrip
         profiles_string.split(', ').each do |profile_string|
+          # Profile string is '<Profile>', '<Profile> [d][i]', or the like
           profile = profile_string.split[0]
           module_hash[:streams][stream][:profiles] << profile
           module_hash[:streams][stream][:default_profile] = profile if profile_string.include?('[d]')
           module_hash[:streams][stream][:installed_profiles] << profile if profile_string.include?('[i]')
         end
       elsif line.split[0] == 'Name'
+        # 'dnf module list' output header is 'Name<Spaces>Stream<Spaces>Profiles<Spaces>...'
+        # Each field has same position of data that follows
         @stream_start = line[/Name\s+/].length
         @stream_length = line[/Stream\s+/].length
         @profiles_start = @stream_start + @stream_length
@@ -33,13 +54,18 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
     module_hash
   end
 
+  # Gets current state of stream and profiles of specified module
+  # Output formatted by function dnf_output_2_hash
   def get_module_state(module_name)
+    # This function can be called multiple times in the same resource call
     return unless @module_state.nil?
     dnf_output = dnf('-q', 'module', 'list', module_name)
   rescue Puppet::ExecutionFailure
+    # Assumes any execution error happens because module doesn't exist
     raise ArgumentError, "Module \"#{module_name}\" not found"
   else
     @module_state = dnf_output_2_hash(dnf_output)
+    # Which stream to use in functions which manage profiles
     case resource[:enabled_stream]
     when false, true
       @profiles_stream = @module_state[:default_stream]
@@ -54,6 +80,7 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
     dnf('-y', 'module', action, module_spec)
   end
 
+  # Checks if all specified profiles exist in module's stream
   def validate_profiles(module_name, specified, existing)
     invalid = specified - existing
     raise ArgumentError, "Profile(s) #{invalid.map{ |profile| "\"#{profile}\""}.join(', ')} " +
@@ -62,8 +89,10 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
 
   def enabled_stream
     get_module_state(resource[:module])
+    # Specified stream = nil requires a previously enabled stream
     raise ArgumentError, "No enabled stream to keep in module \"#{resource[:module]}\"" if
       resource[:enabled_stream].nil? and ! @module_state.key?(:enabled_stream)
+    # Specified stream = true requires an existing default stream
     raise ArgumentError, "No default stream to enable in module \"#{resource[:module]}\"" if
       resource[:enabled_stream] == true and ! @module_state.key?(:default_stream)
     return nil if resource[:enabled_stream].nil?
@@ -86,6 +115,7 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
 
   def installed_profiles
     get_module_state(resource[:module])
+    # Profiles exist inside stream
     if @profiles_stream.nil?
       return [] if resource[:installed_profiles].empty?
       raise ArgumentError, "No enabled or default stream in module \"#{resource[:module]}\""
@@ -93,11 +123,14 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
     stream_contents = @module_state[:streams][@profiles_stream]
     installed = stream_contents[:installed_profiles]
     if resource[:installed_profiles] == [true]
+      # Specified profile = true requires an existing default profile
       raise ArgumentError, "No default profile to install in module:stream \"#{resource[:module]}:#{@profiles_stream}\"" unless
         stream_contents.key?(:default_profile)
+      # Act if default profile isn't installed
       installed.include?(stream_contents[:default_profile]) ? [true] : []
     else
       validate_profiles(resource[:module], resource[:installed_profiles], stream_contents[:profiles])
+      # Only installed profiles included in specified ones are relevant here
       installed & resource[:installed_profiles]
     end
   end

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -163,13 +163,15 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
       @profiles_stream.nil?
     if resource[:removed_profiles] == [true]
       # Act if any currently installed profiles aren't in specified ones
-      (stream_contents[:installed_profiles] - @profiles_to_install).empty? ? [true] : []
+      @profiles_to_remove = stream_contents[:installed_profiles] - @profiles_to_install
+      @profiles_to_remove.empty? ? [true] : []
     else
       conflicting = @profiles_to_install & resource[:removed_profiles]
       raise ArgumentError, "Profile(s) #{conflicting}.join(', ') listed to both install and remove " +
         "in module \"#{resource[:module]}\"" unless conflicting.empty?
       validate_profiles(resource[:module], resource[:removed_profiles], stream_contents[:profiles])
       # Installed profiles become missing from removed list and cause action
+      @profiles_to_remove = resource[:removed_profiles] & stream_contents[:installed_profiles]
       resource[:removed_profiles] - stream_contents[:installed_profiles]
     end
   end

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -5,10 +5,21 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
 
   commands dnf: 'dnf'
 
+  def dnf_output_2_hash(dnf_output)
+    module_hash = {}
+    dnf_output.lines.each do |line|
+      line.chomp!
+      break if line.empty?
+    end
+    module_hash
+  end
+
   def get_module_state(module_name)
-    dnf('-q', 'module', 'list', module_name)
+    dnf_output = dnf('-q', 'module', 'list', module_name)
   rescue Puppet::ExecutionFailure
     raise ArgumentError, "Module \"#{module_name}\" not found"
+  else
+    @module_state = dnf_output_2_hash(dnf_output)
   end
 
   def enabled_stream

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -82,6 +82,7 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
 
   # Checks if all specified profiles exist in module's stream
   def validate_profiles(module_name, specified, existing)
+    return unless specified.is_a?(Array)
     invalid = specified - existing
     raise ArgumentError, "Profile(s) #{invalid.map{ |profile| "\"#{profile}\""}.join(', ')} " +
       "not found in module:stream \"#{module_name}:#{@profiles_stream}\"" unless invalid.empty?

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -3,8 +3,16 @@
 Puppet::Type.type(:dnf_module).provide(:dnf_module) do
   desc 'Unique provider'
 
+  commands dnf: 'dnf'
+
+  def get_module_state(module_name)
+    dnf('-q', 'module', 'list', module_name)
+  rescue Puppet::ExecutionFailure
+    raise ArgumentError, "Module \"#{module_name}\" not found"
+  end
+
   def enabled_stream
-    nil
+    get_module_state(resource[:module])
   end
 
   def enabled_stream=(stream)

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -165,6 +165,10 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
       # Act if any currently installed profiles aren't in specified ones
       (stream_contents[:installed_profiles] - @profiles_to_install).empty? ? [true] : []
     else
+      conflicting = @profiles_to_install & resource[:removed_profiles]
+      raise ArgumentError, "Profile(s) #{conflicting}.join(', ') listed to both install and remove " +
+        "in module \"#{resource[:module]}\"" unless conflicting.empty?
+      validate_profiles(resource[:module], resource[:removed_profiles], stream_contents[:profiles])
       # Installed profiles become missing from removed list and cause action
       resource[:removed_profiles] - stream_contents[:installed_profiles]
     end

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -89,6 +89,10 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
   def installed_profiles=(profiles)
     if profiles == [true]
       dnf('-y', 'module', 'install', resource[:module])
+    else
+      stream = @module_state[:enabled_stream] || @module_state[:default_stream]
+      install = profiles - @module_state[:streams][stream][:installed_profiles]
+      dnf('-y', 'module', 'install', install.map{ |profile| "#{resource[:module]}/#{profile}"}.join(' '))
     end
   end
 end

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -73,6 +73,11 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
       return [] if resource[:installed_profiles].empty?
       raise ArgumentError, "No enabled or default stream in module \"#{resource[:module]}\""
     end
+    installed = @module_state[:streams][stream][:installed_profiles]
+    if resource[:installed_profiles] == [true]
+      raise ArgumentError, "No default profile to install in module:stream \"#{resource[:module]}:#{stream}\"" unless
+        @module_state[:streams][stream].key?(:default_profile)
+    end
   end
 
   def installed_profiles=(profiles)

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -15,11 +15,13 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
         stream = stream_string.split[0]
         module_hash[:default_stream] = stream if stream_string.include?('[d]')
         module_hash[:enabled_stream] = stream if stream_string.include?('[e]')
-        module_hash[:streams][stream] = {profiles: []}
+        module_hash[:streams][stream] = {profiles: [], installed_profiles: []}
         profiles_string = line[@profiles_start, @profiles_length].rstrip
         profiles_string.split(', ').each do |profile_string|
           profile = profile_string.split[0]
           module_hash[:streams][stream][:profiles] << profile
+          module_hash[:streams][stream][:default_profile] = profile if profile_string.include?('[d]')
+          module_hash[:streams][stream][:installed_profiles] << profile if profile_string.include?('[i]')
         end
       elsif line.split[0] == 'Name'
         @stream_start = line[/Name\s+/].length

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -95,11 +95,16 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
     # Specified stream = true requires an existing default stream
     raise ArgumentError, "No default stream to enable in module \"#{resource[:module]}\"" if
       resource[:enabled_stream] == true and ! @module_state.key?(:default_stream)
-    return nil if resource[:enabled_stream].nil?
-    return false unless @module_state.key?(:enabled_stream)
-    return true if resource[:enabled_stream] == true and
+    case resource[:enabled_stream]
+    when nil    # Nothing to do
+      nil
+    when false  # Act if any stream is enabled
+      @module_state.key?(:enabled_stream)
+    when true   # Act if default stream isn't enabled
       @module_state[:enabled_stream] == @module_state[:default_stream]
-    @module_state[:enabled_stream]
+    else        # Act if specified stream isn't enabled
+      @module_state[:enabled_stream]
+    end
   end
 
   def enabled_stream=(stream)

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -77,6 +77,10 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
     if resource[:installed_profiles] == [true]
       raise ArgumentError, "No default profile to install in module:stream \"#{resource[:module]}:#{stream}\"" unless
         @module_state[:streams][stream].key?(:default_profile)
+    else
+      invalid = resource[:installed_profiles] - @module_state[:streams][stream][:profiles]
+      raise ArgumentError, "Profile(s) #{invalid.map{ |profile| "\"#{profile}\""}.join(', ')} " +
+        "not found in module:stream \"#{resource[:module]}:#{stream}\"" unless invalid.empty?
     end
   end
 

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -46,6 +46,13 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
   end
 
   def enabled_stream=(stream)
-    nil
+    case stream
+    when false
+      dnf('-y', 'module', 'reset', resource[:module])
+    when true
+      dnf('-y', 'module', 'switch-to', "#{resource[:module]}:#{@module_state[:default_stream]}")
+    else
+      dnf('-y', 'module', 'switch-to', "#{resource[:module]}:#{stream}")
+    end
   end
 end

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -77,10 +77,12 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
     if resource[:installed_profiles] == [true]
       raise ArgumentError, "No default profile to install in module:stream \"#{resource[:module]}:#{stream}\"" unless
         @module_state[:streams][stream].key?(:default_profile)
+      installed.include?(@module_state[:streams][stream][:default_profile]) ? [true] : []
     else
       invalid = resource[:installed_profiles] - @module_state[:streams][stream][:profiles]
       raise ArgumentError, "Profile(s) #{invalid.map{ |profile| "\"#{profile}\""}.join(', ')} " +
         "not found in module:stream \"#{resource[:module]}:#{stream}\"" unless invalid.empty?
+      installed & resource[:installed_profiles]
     end
   end
 

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -161,6 +161,10 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
     # Profiles exist inside stream
     raise ArgumentError, "No enabled or default stream in module \"#{resource[:module]}\"" if
       @profiles_stream.nil?
+    if resource[:removed_profiles] == [true]
+      # Act if any currently installed profiles aren't in specified ones
+      (stream_contents[:installed_profiles] - @profiles_to_install).empty? ? [true] : []
+    end
   end
 
   def removed_profiles=(profiles)

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -164,6 +164,9 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
     if resource[:removed_profiles] == [true]
       # Act if any currently installed profiles aren't in specified ones
       (stream_contents[:installed_profiles] - @profiles_to_install).empty? ? [true] : []
+    else
+      # Installed profiles become missing from removed list and cause action
+      resource[:removed_profiles] - stream_contents[:installed_profiles]
     end
   end
 

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -87,6 +87,8 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
   end
 
   def installed_profiles=(profiles)
-    nil
+    if profiles == [true]
+      dnf('-y', 'module', 'install', resource[:module])
+    end
   end
 end

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -38,6 +38,10 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
       resource[:enabled_stream].nil? and ! @module_state.key?(:enabled_stream)
     raise ArgumentError, "No default stream to enable in module \"#{resource[:module]}\"" if
       resource[:enabled_stream] == true and ! @module_state.key?(:default_stream)
+    return nil if resource[:enabled_stream].nil?
+    return false unless @module_state.key?(:enabled_stream)
+    return true if resource[:enabled_stream] == true and
+      @module_state[:enabled_stream] == @module_state[:default_stream]
   end
 
   def enabled_stream=(stream)

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -155,6 +155,7 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
   end
 
   def removed_profiles
+    return resource[:removed_profiles] if resource[:removed_profiles].nil? or resource[:removed_profiles].empty?
     get_module_state(resource[:module])
     stream_contents = @module_state[:streams][@profiles_stream]
     # Profiles exist inside stream

--- a/lib/puppet/provider/dnf_module/dnf_module.rb
+++ b/lib/puppet/provider/dnf_module/dnf_module.rb
@@ -15,10 +15,17 @@ Puppet::Type.type(:dnf_module).provide(:dnf_module) do
         stream = stream_string.split[0]
         module_hash[:default_stream] = stream if stream_string.include?('[d]')
         module_hash[:enabled_stream] = stream if stream_string.include?('[e]')
-        module_hash[:streams][stream] = {}
+        module_hash[:streams][stream] = {profiles: []}
+        profiles_string = line[@profiles_start, @profiles_length].rstrip
+        profiles_string.split(', ').each do |profile_string|
+          profile = profile_string.split[0]
+          module_hash[:streams][stream][:profiles] << profile
+        end
       elsif line.split[0] == 'Name'
         @stream_start = line[/Name\s+/].length
         @stream_length = line[/Stream\s+/].length
+        @profiles_start = @stream_start + @stream_length
+        @profiles_length = line[/Profiles\s+/].length
       end
     end
     module_hash

--- a/lib/puppet/type/dnf_module.rb
+++ b/lib/puppet/type/dnf_module.rb
@@ -3,10 +3,17 @@
 Puppet::Type.newtype(:dnf_module) do
   @doc = <<-EOS
     @summary Manage DNF modules
+    @example Enable MariaDB 10.5 stream
+      dnf_module { 'mariadb_10.5':
+        module         => 'mariadb',
+        enabled_stream => '10.5',
+      }
     @param title
       Resource unique id
     @param module
       Module to be managed
+    @param enabled_stream
+      Module stream to be enabled
 
     This type allows Puppet to enable/disable streams and install/remove profiles via DNF modules
 EOS
@@ -21,4 +28,19 @@ EOS
       raise TypeError, 'Module name should be a string' unless value.is_a?(String)
     end
   end
+
+  newproperty(:enabled_stream) do
+    desc <<-EOS
+      Module stream that should be enabled
+        String - Specify stream
+        true - Default stream
+        false - No stream (resets module)
+        nil (default) - Keep current
+    EOS
+    validate do |value|
+      raise TypeError, 'Module stream should be a string, true, false or undef' unless
+        [true, false, nil].include?(value) or value.is_a?(String)
+    end
+  end
+
 end

--- a/lib/puppet/type/dnf_module.rb
+++ b/lib/puppet/type/dnf_module.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Puppet::Type.newtype(:dnf_module) do
+  @doc = <<-EOS
+    @summary Manage DNF modules
+
+    This type allows Puppet to enable/disable streams and install/remove profiles via DNF modules
+EOS
+end

--- a/lib/puppet/type/dnf_module.rb
+++ b/lib/puppet/type/dnf_module.rb
@@ -68,5 +68,6 @@ EOS
         String or Array - Specify profile(s)
         true - All not listed in installed_profiles
     EOS
+    defaultto []
   end
 end

--- a/lib/puppet/type/dnf_module.rb
+++ b/lib/puppet/type/dnf_module.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Puppet::Type.newtype(:dnf_module) do
-  @doc = <<-EOS
+  @doc = <<-TYPE_DOC
     @summary Manage DNF modules
     @example Install MariaDB 10.5 Galera profile
       dnf_module { 'mariadb_galera_10.5':
@@ -22,7 +22,7 @@ Puppet::Type.newtype(:dnf_module) do
       Module profile(s) to be removed
 
     This type allows Puppet to enable/disable streams and install/remove profiles via DNF modules
-EOS
+  TYPE_DOC
 
   newparam(:title, namevar: true) do
     desc 'Resource title'
@@ -46,7 +46,7 @@ EOS
     EOS
     validate do |value|
       raise TypeError, 'Module stream should be a string, true, false or undef' unless
-        [true, false, nil].include?(value) or value.is_a?(String)
+        [true, false, nil].include?(value) || value.is_a?(String)
     end
     def insync?(is)
       Puppet.debug { "enabled_stream - is: \"#{is}\" - should: \"#{should}\"" }
@@ -54,7 +54,7 @@ EOS
     end
   end
 
-  newproperty(:installed_profiles, :array_matching => :all) do
+  newproperty(:installed_profiles, array_matching: 'all') do
     desc <<-EOS
       Module profile(s) that should be installed
         String or Array - Specify profile(s)
@@ -63,7 +63,7 @@ EOS
     defaultto []
     validate do |value|
       raise TypeError, 'Module profiles should be a string, an array of strings or true' unless
-        value == true or value.is_a?(String)
+        value == true || value.is_a?(String)
     end
     # Ignore profiles order if user provided a list
     def insync?(is)
@@ -72,7 +72,7 @@ EOS
     end
   end
 
-  newproperty(:removed_profiles, :array_matching => :all) do
+  newproperty(:removed_profiles, array_matching: 'all') do
     desc <<-EOS
       Module profile(s) that should be removed
         String or Array - Specify profile(s)
@@ -81,7 +81,7 @@ EOS
     defaultto []
     validate do |value|
       raise TypeError, 'Module profiles should be a string, an array of strings or true' unless
-        value == true or value.is_a?(String)
+        value == true || value.is_a?(String)
     end
     # Ignore profiles order if user provided a list
     def insync?(is)

--- a/lib/puppet/type/dnf_module.rb
+++ b/lib/puppet/type/dnf_module.rb
@@ -8,6 +8,7 @@ Puppet::Type.newtype(:dnf_module) do
         module             => 'mariadb',
         enabled_stream     => '10.5',
         installed_profiles => 'galera',
+        removed_profiles   => true,
       }
     @param title
       Resource unique id
@@ -17,6 +18,8 @@ Puppet::Type.newtype(:dnf_module) do
       Module stream to be enabled
     @param installed_profiles
       Module profile(s) to be installed
+    @param removed_profiles
+      Module profile(s) to be removed
 
     This type allows Puppet to enable/disable streams and install/remove profiles via DNF modules
 EOS
@@ -57,5 +60,13 @@ EOS
       raise TypeError, 'Module profiles should be a string, an array of strings or true' unless
         value == true or value.is_a?(String)
     end
+  end
+
+  newproperty(:removed_profiles, :array_matching => :all) do
+    desc <<-EOS
+      Module profile(s) that should be removed
+        String or Array - Specify profile(s)
+        true - All not listed in installed_profiles
+    EOS
   end
 end

--- a/lib/puppet/type/dnf_module.rb
+++ b/lib/puppet/type/dnf_module.rb
@@ -69,5 +69,9 @@ EOS
         true - All not listed in installed_profiles
     EOS
     defaultto []
+    validate do |value|
+      raise TypeError, 'Module profiles should be a string, an array of strings or true' unless
+        value == true or value.is_a?(String)
+    end
   end
 end

--- a/lib/puppet/type/dnf_module.rb
+++ b/lib/puppet/type/dnf_module.rb
@@ -52,5 +52,10 @@ EOS
         String or Array - Specify profile(s)
         true - Default profile
     EOS
+    defaultto []
+    validate do |value|
+      raise TypeError, 'Module profiles should be a string, an array of strings or true' unless
+        value == true or value.is_a?(String)
+    end
   end
 end

--- a/lib/puppet/type/dnf_module.rb
+++ b/lib/puppet/type/dnf_module.rb
@@ -3,10 +3,11 @@
 Puppet::Type.newtype(:dnf_module) do
   @doc = <<-EOS
     @summary Manage DNF modules
-    @example Enable MariaDB 10.5 stream
-      dnf_module { 'mariadb_10.5':
-        module         => 'mariadb',
-        enabled_stream => '10.5',
+    @example Install MariaDB 10.5 Galera profile
+      dnf_module { 'mariadb_galera_10.5':
+        module             => 'mariadb',
+        enabled_stream     => '10.5',
+        installed_profiles => 'galera',
       }
     @param title
       Resource unique id
@@ -14,6 +15,8 @@ Puppet::Type.newtype(:dnf_module) do
       Module to be managed
     @param enabled_stream
       Module stream to be enabled
+    @param installed_profiles
+      Module profile(s) to be installed
 
     This type allows Puppet to enable/disable streams and install/remove profiles via DNF modules
 EOS
@@ -43,4 +46,11 @@ EOS
     end
   end
 
+  newproperty(:installed_profiles, :array_matching => :all) do
+    desc <<-EOS
+      Module profile(s) that should be installed
+        String or Array - Specify profile(s)
+        true - Default profile
+    EOS
+  end
 end

--- a/lib/puppet/type/dnf_module.rb
+++ b/lib/puppet/type/dnf_module.rb
@@ -3,7 +3,22 @@
 Puppet::Type.newtype(:dnf_module) do
   @doc = <<-EOS
     @summary Manage DNF modules
+    @param title
+      Resource unique id
+    @param module
+      Module to be managed
 
     This type allows Puppet to enable/disable streams and install/remove profiles via DNF modules
 EOS
+
+  newparam(:title, namevar: true) do
+    desc 'Resource title'
+  end
+
+  newparam(:module) do
+    desc 'Module to be managed (String)'
+    validate do |value|
+      raise TypeError, 'Module name should be a string' unless value.is_a?(String)
+    end
+  end
 end

--- a/lib/puppet/type/dnf_module.rb
+++ b/lib/puppet/type/dnf_module.rb
@@ -31,6 +31,7 @@ EOS
   newparam(:module) do
     desc 'Module to be managed (String)'
     validate do |value|
+      Puppet.debug { "Module: \"#{value}\"" }
       raise TypeError, 'Module name should be a string' unless value.is_a?(String)
     end
   end
@@ -47,6 +48,10 @@ EOS
       raise TypeError, 'Module stream should be a string, true, false or undef' unless
         [true, false, nil].include?(value) or value.is_a?(String)
     end
+    def insync?(is)
+      Puppet.debug { "enabled_stream - is: \"#{is}\" - should: \"#{should}\"" }
+      is == should
+    end
   end
 
   newproperty(:installed_profiles, :array_matching => :all) do
@@ -62,6 +67,7 @@ EOS
     end
     # Ignore profiles order if user provided a list
     def insync?(is)
+      Puppet.debug { "installed_profiles - is: \"#{is}\" - should: \"#{should}\"" }
       is.is_a?(Array) ? is.sort == should.sort : is == should
     end
   end
@@ -79,6 +85,7 @@ EOS
     end
     # Ignore profiles order if user provided a list
     def insync?(is)
+      Puppet.debug { "removed_profiles - is: \"#{is}\" - should: \"#{should}\"" }
       is.is_a?(Array) ? is.sort == should.sort : is == should
     end
   end

--- a/lib/puppet/type/dnf_module.rb
+++ b/lib/puppet/type/dnf_module.rb
@@ -60,6 +60,10 @@ EOS
       raise TypeError, 'Module profiles should be a string, an array of strings or true' unless
         value == true or value.is_a?(String)
     end
+    # Ignore profiles order if user provided a list
+    def insync?(is)
+      is.is_a?(Array) ? is.sort == should.sort : is == should
+    end
   end
 
   newproperty(:removed_profiles, :array_matching => :all) do
@@ -72,6 +76,10 @@ EOS
     validate do |value|
       raise TypeError, 'Module profiles should be a string, an array of strings or true' unless
         value == true or value.is_a?(String)
+    end
+    # Ignore profiles order if user provided a list
+    def insync?(is)
+      is.is_a?(Array) ? is.sort == should.sort : is == should
     end
   end
 end

--- a/spec/unit/puppet/provider/dnf_module/dnf_module_spec.rb
+++ b/spec/unit/puppet/provider/dnf_module/dnf_module_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+dnf_module = Puppet::Type.type(:dnf_module).provide(:dnf_module)
+RSpec.describe dnf_module do
+  it 'loads' do
+    expect(dnf_module).not_to be_nil
+  end
+end

--- a/spec/unit/puppet/type/dnf_module_spec.rb
+++ b/spec/unit/puppet/type/dnf_module_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe 'the dnf_module type' do
     %i[title module]
   end
 
+  let :properties do
+    %i[enabled_stream]
+  end
+
   it 'loads' do
     expect(dnf_module).not_to be_nil
   end
@@ -15,6 +19,12 @@ RSpec.describe 'the dnf_module type' do
   it 'has expected parameters' do
     params.each do |param|
       expect(dnf_module.parameters).to be_include(param)
+    end
+  end
+
+  it 'has expected properties' do
+    properties.each do |property|
+      expect(dnf_module.properties.map(&:name)).to be_include(property)
     end
   end
 end

--- a/spec/unit/puppet/type/dnf_module_spec.rb
+++ b/spec/unit/puppet/type/dnf_module_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'the dnf_module type' do
   end
 
   let :properties do
-    %i[enabled_stream installed_profiles]
+    %i[enabled_stream installed_profiles removed_profiles]
   end
 
   it 'loads' do

--- a/spec/unit/puppet/type/dnf_module_spec.rb
+++ b/spec/unit/puppet/type/dnf_module_spec.rb
@@ -4,7 +4,17 @@ require 'spec_helper'
 
 dnf_module = Puppet::Type.type(:dnf_module)
 RSpec.describe 'the dnf_module type' do
+  let :params do
+    %i[title module]
+  end
+
   it 'loads' do
     expect(dnf_module).not_to be_nil
+  end
+
+  it 'has expected parameters' do
+    params.each do |param|
+      expect(dnf_module.parameters).to be_include(param)
+    end
   end
 end

--- a/spec/unit/puppet/type/dnf_module_spec.rb
+++ b/spec/unit/puppet/type/dnf_module_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'the dnf_module type' do
   end
 
   let :properties do
-    %i[enabled_stream]
+    %i[enabled_stream installed_profiles]
   end
 
   it 'loads' do

--- a/spec/unit/puppet/type/dnf_module_spec.rb
+++ b/spec/unit/puppet/type/dnf_module_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+dnf_module = Puppet::Type.type(:dnf_module)
+RSpec.describe 'the dnf_module type' do
+  it 'loads' do
+    expect(dnf_module).not_to be_nil
+  end
+end


### PR DESCRIPTION
This PR adds suport for [DNF modules](https://dnf.readthedocs.io/en/latest/modularity.html) management, making it possible to enable/disable streams and install/uninstall full profiles, in a more comprehensive and broad way than `package` resource's `dnfmodule` provider.

#### This Pull Request (PR) fixes the following issues
Fixes #310 