### PR TITLE
Add openEuler as a supporting operating system.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -86,7 +86,14 @@
         "36",
         "37"
       ]
+    },
+    {
+      "operatingsystem": "openEuler",
+      "operatingsystemrelease": [
+        "22"
+      ]
     }
+
   ],
   "requirements": [
     {


### PR DESCRIPTION
#### Pull Request (PR) description

This PR add openEuler 22 https://www.openeuler.org/ as a supporting OS. openEuler is a community-driven Linux distro which adopts yum as its package manager. We've tested it in our openEuler cluster. We appreciate if this patch can be back ported to puppet-yum v6.x branch.

Thank you!
