### PR TITLE
Handle changes in package group definitions.

### DIFF
--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -24,7 +24,7 @@ define yum::group (
     'present', 'installed', default: {
       exec { "yum-groupinstall-${name}":
         command => join(concat(["yum -y group install '${name}'"], $install_options), ' '),
-        unless  => "yum group list hidden '${name}' | egrep -i '^Installed.+Groups:$'",
+        unless  => "test $(yum --assumeno group install '${name}' 2>/dev/null| grep -c '^Install.*Package') -eq 0",
         timeout => $timeout,
       }
       if $ensure == 'latest' {

--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -23,14 +23,14 @@ define yum::group (
   case $ensure {
     'present', 'installed', default: {
       exec { "yum-groupinstall-${name}":
-        command => join(concat(["yum -y groupinstall '${name}'"], $install_options), ' '),
-        unless  => "yum grouplist hidden '${name}' | egrep -i '^Installed.+Groups:$'",
+        command => join(concat(["yum -y group install '${name}'"], $install_options), ' '),
+        unless  => "yum group list hidden '${name}' | egrep -i '^Installed.+Groups:$'",
         timeout => $timeout,
       }
       if $ensure == 'latest' {
         exec { "yum-groupinstall-${name}-latest":
-          command => join(concat(["yum -y groupinstall '${name}'"], $install_options), ' '),
-          onlyif  => "yum groupinfo '${name}' | egrep '\\s+\\+'",
+          command => join(concat(["yum -y group install '${name}'"], $install_options), ' '),
+          unless  => 'test $(yum --assumeno group install DVT-Full 2>/dev/null| grep -c "^Install.*Package\|^Upgrade.*Package") -eq 0',
           timeout => $timeout,
           require => Exec["yum-groupinstall-${name}"],
         }

--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -30,7 +30,7 @@ define yum::group (
       if $ensure == 'latest' {
         exec { "yum-groupinstall-${name}-latest":
           command => join(concat(["yum -y group install '${name}'"], $install_options), ' '),
-          unless  => 'test $(yum --assumeno group install DVT-Full 2>/dev/null| grep -c "^Install.*Package\|^Upgrade.*Package") -eq 0',
+          unless  => "test $(yum --assumeno group install '${name}' 2>/dev/null| grep -c '^Install.*Package\|^Upgrade.*Package') -eq 0",
           timeout => $timeout,
           require => Exec["yum-groupinstall-${name}"],
         }

--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -36,11 +36,10 @@ define yum::group (
       }
     }
     'latest': { # install the yum group and update if any packages are out of date.
-      exec { "yum-groupinstall-${name}-latest":
+      exec { "yum-groupinstall-${name}":
         command => join(concat(["yum -y group install '${name}'"], $install_options), ' '),
-        unless  => "test $(yum --assumeno group install '${name}' 2>/dev/null| grep -c '^Install.*Package\|^Upgrade.*Package') -eq 0",
+        unless  => "test $(yum --assumeno group install '${name}' 2>/dev/null| grep -c -e '^Install.*Package' -e '^Upgrade.*Package') -eq 0",
         timeout => $timeout,
-        require => Exec["yum-groupinstall-${name}"],
       }
     }
     'absent', 'purged': {


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Handles differences in yum group definitions.  We found if the upstream comps.xml is changed in the repository that yum::group resources would not issue an install regardless whether ensure is set to present or latest.

#### This Pull Request (PR) fixes the following issues

Not sure if this is an issue for others.  But, we found the current behavior unexpected.  If comps.xml is updated upstream and yum::group is set to latest I expect puppet to resolve those differences and install the missing packages.
