### PR TITLE
Add support for dnf5

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -553,7 +553,7 @@ Default value: `'present'`
 
 Data type: `Optional[Integer]`
 
-exec timeout for yum groupinstall command
+exec timeout for yum group install command
 
 Default value: `undef`
 
@@ -561,7 +561,7 @@ Default value: `undef`
 
 Data type: `Array[String[1]]`
 
-options provided to yum groupinstall command
+options provided to yum group install command
 
 Default value: `[]`
 

--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -2,8 +2,8 @@
 # @summary This definition installs or removes yum package group.
 #
 # @param ensure specifies if package group should be present (installed) or absent (purged)
-# @param timeout exec timeout for yum groupinstall command
-# @param install_options options provided to yum groupinstall command
+# @param timeout exec timeout for yum group install command
+# @param install_options options provided to yum group install command
 #
 # @example Sample usage:
 #   yum::group { 'X Window System':
@@ -23,14 +23,14 @@ define yum::group (
   case $ensure {
     'present', 'installed', default: {
       exec { "yum-groupinstall-${name}":
-        command => join(concat(["yum -y groupinstall '${name}'"], $install_options), ' '),
-        unless  => "yum grouplist hidden '${name}' | egrep -i '^Installed.+Groups:$'",
+        command => join(concat(["yum -y group install '${name}'"], $install_options), ' '),
+        unless  => "yum group list hidden '${name}' | egrep -i '^Installed.+Groups:$'",
         timeout => $timeout,
       }
       if $ensure == 'latest' {
         exec { "yum-groupinstall-${name}-latest":
-          command => join(concat(["yum -y groupinstall '${name}'"], $install_options), ' '),
-          onlyif  => "yum groupinfo '${name}' | egrep '\\s+\\+'",
+          command => join(concat(["yum -y group install '${name}'"], $install_options), ' '),
+          onlyif  => "yum group info '${name}' | egrep '\\s+\\+'",
           timeout => $timeout,
           require => Exec["yum-groupinstall-${name}"],
         }
@@ -39,8 +39,8 @@ define yum::group (
 
     'absent', 'purged': {
       exec { "yum-groupremove-${name}":
-        command => "yum -y groupremove '${name}'",
-        onlyif  => "yum grouplist hidden '${name}' | egrep -i '^Installed.+Groups:$'",
+        command => "yum -y group remove '${name}'",
+        onlyif  => "yum group list hidden '${name}' | egrep -i '^Installed.+Groups:$'",
         timeout => $timeout,
       }
     }

--- a/spec/acceptance/define_group_spec.rb
+++ b/spec/acceptance/define_group_spec.rb
@@ -18,7 +18,7 @@ describe 'managing a yum::group' do
     end
 
     # On stupid 7 test package has to be leaf package
-    # to be removed with a "groupremove". Can't find
+    # to be removed with a "group remove". Can't find
     # a common package that works.
     case fact('os.release.major')
     when '7'

--- a/spec/defines/group_spec.rb
+++ b/spec/defines/group_spec.rb
@@ -7,7 +7,7 @@ describe 'yum::group' do
     let(:title) { 'Core' }
 
     it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_exec("yum-groupinstall-#{title}").with_command("yum -y groupinstall 'Core'") }
+    it { is_expected.to contain_exec("yum-groupinstall-#{title}").with_command("yum -y group install 'Core'") }
   end
 
   context 'when ensure is set to `absent`' do
@@ -15,7 +15,7 @@ describe 'yum::group' do
     let(:params) { { ensure: 'absent' } }
 
     it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_exec("yum-groupremove-#{title}").with_command("yum -y groupremove 'Core'") }
+    it { is_expected.to contain_exec("yum-groupremove-#{title}").with_command("yum -y group remove 'Core'") }
   end
 
   context 'with a timeout specified' do
@@ -31,7 +31,7 @@ describe 'yum::group' do
     let(:params) { { install_options: ['--enablerepo=epel'] } }
 
     it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_exec("yum-groupinstall-#{title}").with_command("yum -y groupinstall 'Core' --enablerepo=epel") }
+    it { is_expected.to contain_exec("yum-groupinstall-#{title}").with_command("yum -y group install 'Core' --enablerepo=epel") }
   end
 
   context 'when ensure is set to `latest`' do
@@ -39,7 +39,7 @@ describe 'yum::group' do
     let(:params) { { ensure: 'latest' } }
 
     it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_exec("yum-groupinstall-#{title}").with_command("yum -y groupinstall 'Core'") }
-    it { is_expected.to contain_exec("yum-groupinstall-#{title}-latest").with_command("yum -y groupinstall 'Core'") }
+    it { is_expected.to contain_exec("yum-groupinstall-#{title}").with_command("yum -y group install 'Core'") }
+    it { is_expected.to contain_exec("yum-groupinstall-#{title}-latest").with_command("yum -y group install 'Core'") }
   end
 end


### PR DESCRIPTION
This adds support for dnf5, which no longer supports the old syntax. This will probably break support for rhel6 and lower. rhel7 already supports this syntax.

Fixes #338
