### PR TITLE
Sometimes version or release is a simple number

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -841,7 +841,7 @@ Default value: `'*'`
 
 ##### <a name="-yum--versionlock--epoch"></a>`epoch`
 
-Data type: `Integer[0]`
+Data type: `Variant[Integer[0], Pattern[/^[1-9]\d*$/]]`
 
 Epoch of the package if CentOS 8 mechanism is used.
 
@@ -1025,7 +1025,7 @@ Examples 3.4 3.4.el6, 3.4.el6_2
 * **See also**
   * http://ftp.rpm.org/max-rpm/ch-rpm-file-format.html
 
-Alias of `Pattern[/\A([^-]+)\z/]`
+Alias of `Variant[Pattern[/\A([^-]+)\z/], Integer[0,], Float[0,]]`
 
 ### <a name="Yum--RpmVersion"></a>`Yum::RpmVersion`
 
@@ -1036,7 +1036,7 @@ Examples 3.4, 2.5.alpha6
 * **See also**
   * http://ftp.rpm.org/max-rpm/ch-rpm-file-format.html
 
-Alias of `Pattern[/\A([^-]+)\z/]`
+Alias of `Variant[Pattern[/\A([^-]+)\z/], Integer[0,], Float[0,]]`
 
 ### <a name="Yum--VersionlockString"></a>`Yum::VersionlockString`
 

--- a/manifests/versionlock.pp
+++ b/manifests/versionlock.pp
@@ -54,11 +54,11 @@
 #
 # @see http://man7.org/linux/man-pages/man1/yum-versionlock.1.html
 define yum::versionlock (
-  Enum['present', 'absent', 'exclude']      $ensure  = 'present',
-  Optional[Yum::RpmVersion]                 $version = undef,
-  Yum::RpmRelease                           $release = '*',
-  Integer[0]                                $epoch   = 0,
-  Variant[Yum::RpmArch, Enum['*']]          $arch    = '*',
+  Enum['present', 'absent', 'exclude']       $ensure  = 'present',
+  Optional[Yum::RpmVersion]                  $version = undef,
+  Yum::RpmRelease                            $release = '*',
+  Variant[Integer[0], Pattern[/^[1-9]\d*$/]] $epoch   = 0,
+  Variant[Yum::RpmArch, Enum['*']]           $arch    = '*',
 ) {
   require yum::plugin::versionlock
 

--- a/spec/defines/versionlock_spec.rb
+++ b/spec/defines/versionlock_spec.rb
@@ -117,11 +117,30 @@ describe 'yum::versionlock' do
       end
     end
 
-    context 'with version, release, epoch and arch set' do
+    context 'with version, release, epoch and arch set as strings' do
       let(:params) do
         {
           version: '4.3',
           release: '3.2',
+          arch: 'arm',
+          epoch: '42'
+        }
+      end
+
+      context 'it works' do
+        it { is_expected.to compile.with_all_deps }
+
+        it 'contains a well-formed Concat::Fragment' do
+          is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("42:bash-4.3-3.2.arm\n")
+        end
+      end
+    end
+
+    context 'with version, release, epoch and arch set as numbers' do
+      let(:params) do
+        {
+          version: 4.3,
+          release: 3.2,
           arch: 'arm',
           epoch: 42
         }

--- a/spec/type_aliases/yum_rpmrelease_spec.rb
+++ b/spec/type_aliases/yum_rpmrelease_spec.rb
@@ -3,11 +3,14 @@
 require 'spec_helper'
 
 describe 'Yum::Rpmrelease' do
+  it { is_expected.to allow_value(3) }
+  it { is_expected.to allow_value(3.2) }
   it { is_expected.to allow_value('3.2') }
   it { is_expected.to allow_value('3.2alpha23') }
   it { is_expected.to allow_value('3.2_alpha23') }
   it { is_expected.to allow_value('3.2.el8') }
   it { is_expected.to allow_value('3.2.el8_5') }
+  it { is_expected.not_to allow_values(-3) }
   it { is_expected.not_to allow_values('4-3') }
   it { is_expected.not_to allow_values('-3') }
   it { is_expected.not_to allow_values('3-') }

--- a/spec/type_aliases/yum_rpmversion_spec.rb
+++ b/spec/type_aliases/yum_rpmversion_spec.rb
@@ -3,9 +3,12 @@
 require 'spec_helper'
 
 describe 'Yum::Rpmversion' do
+  it { is_expected.to allow_value(3) }
+  it { is_expected.to allow_value(3.2) }
   it { is_expected.to allow_value('3.2') }
   it { is_expected.to allow_value('3.2alpha23') }
   it { is_expected.to allow_value('3.2_alpha23') }
+  it { is_expected.not_to allow_values(-3) }
   it { is_expected.not_to allow_values('4-3') }
   it { is_expected.not_to allow_values('-3') }
   it { is_expected.not_to allow_values('3-') }

--- a/types/rpmrelease.pp
+++ b/types/rpmrelease.pp
@@ -3,4 +3,4 @@
 # Output of `rpm -q --queryformat '%{release}\n' package`.
 # Examples 3.4 3.4.el6, 3.4.el6_2
 # @see http://ftp.rpm.org/max-rpm/ch-rpm-file-format.html
-type Yum::RpmRelease = Pattern[/\A([^-]+)\z/]
+type Yum::RpmRelease = Variant[Pattern[/\A([^-]+)\z/], Integer[0,], Float[0,]]

--- a/types/rpmversion.pp
+++ b/types/rpmversion.pp
@@ -3,4 +3,4 @@
 # Output of `rpm -q --queryformat '%{version}\n' package`.
 # Examples 3.4, 2.5.alpha6
 # @see http://ftp.rpm.org/max-rpm/ch-rpm-file-format.html
-type Yum::RpmVersion = Pattern[/\A([^-]+)\z/]
+type Yum::RpmVersion = Variant[Pattern[/\A([^-]+)\z/], Integer[0,], Float[0,]]


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Sometimes the package version or release is a simple number.  If I forget to quote it, the templates do just fine.  This reduces the instances where I need to explicitly cast `3.4` as a string.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
