### PR TITLE
Handle changes in package group definitions.

### DIFF
--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -36,7 +36,7 @@ define yum::group (
       }
     }
     'latest': { # install the yum group and update if any packages are out of date.
-      exec { "yum-groupinstall-${name}":
+      exec { "yum-groupinstall-${name}-latest":
         command => join(concat(["yum -y group install '${name}'"], $install_options), ' '),
         unless  => "test $(yum --assumeno group install '${name}' 2>/dev/null| grep -c -e '^Install.*Package' -e '^Upgrade.*Package') -eq 0",
         timeout => $timeout,

--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -44,7 +44,7 @@ define yum::group (
     }
     'absent', 'purged': {
       exec { "yum-groupremove-${name}":
-        command => "yum -y groupremove '${name}'",
+        command => "yum -y group remove '${name}'",
         onlyif  => "yum grouplist hidden '${name}' | egrep -i '^Installed.+Groups:$'",
         timeout => $timeout,
       }

--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -21,26 +21,31 @@ define yum::group (
   }
 
   case $ensure {
-    'present', 'installed', default: {
+    'present', default: { # just install the yum group and ensure the group is present.
       exec { "yum-groupinstall-${name}":
         command => join(concat(["yum -y group install '${name}'"], $install_options), ' '),
-        unless  => "yum group list hidden '${name}' | egrep -i '^Installed.+Groups:$'",
+        unless  => "yum grouplist hidden '${name}' | egrep -i '^Installed.+Groups:$'",
         timeout => $timeout,
       }
-      if $ensure == 'latest' {
-        exec { "yum-groupinstall-${name}-latest":
-          command => join(concat(["yum -y group install '${name}'"], $install_options), ' '),
-          onlyif  => "yum group info '${name}' | egrep '\\s+\\+'",
-          timeout => $timeout,
-          require => Exec["yum-groupinstall-${name}"],
-        }
+    }
+    'installed': { # install the yum group and re-install if any packages are missing.
+      exec { "yum-groupinstall-${name}":
+        command => join(concat(["yum -y group install '${name}'"], $install_options), ' '),
+        unless  => "test $(yum --assumeno group install '${name}' 2>/dev/null| grep -c '^Install.*Package') -eq 0",
+        timeout => $timeout,
       }
     }
-
+    'latest': { # install the yum group and update if any packages are out of date.
+      exec { "yum-groupinstall-${name}":
+        command => join(concat(["yum -y group install '${name}'"], $install_options), ' '),
+        unless  => "test $(yum --assumeno group install '${name}' 2>/dev/null| grep -c -e '^Install.*Package' -e '^Upgrade.*Package') -eq 0",
+        timeout => $timeout,
+      }
+    }
     'absent', 'purged': {
       exec { "yum-groupremove-${name}":
-        command => "yum -y group remove '${name}'",
-        onlyif  => "yum group list hidden '${name}' | egrep -i '^Installed.+Groups:$'",
+        command => "yum -y groupremove '${name}'",
+        onlyif  => "yum grouplist hidden '${name}' | egrep -i '^Installed.+Groups:$'",
         timeout => $timeout,
       }
     }


### PR DESCRIPTION
#### Pull Request (PR) description

Handles differences in yum group definitions. We found if the upstream comps.xml is changed in the repository that yum::group resources would not issue an install regardless whether ensure is set to present or latest.  While the internet dnf/yum repositories don't often change package group definitions, private repositories can and do use package groups internally and do change them regularly.

#### This Pull Request (PR) fixes the following issues

When the upstream comps.xml is changed and the package group definition is updated then ensure => present or ensure => latest will resolve the differences and install the missing packages.  This was in a previous pull request (#346) but was never merged.  I've re-based my fork and created a new pull request.