### PR TITLE
Remove yum support from versionlock plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ This module provides helpful definitions for dealing with *yum*.
 Module has been tested on:
 
 * Puppet 4.10.9 and newer
-* CentOS 7,8
+* CentOS 8,9
 * Amazon Linux 2017
-* RHEL 7
+* RHEL 8,9
 * Fedora 35,36
 
 For the official list of all tested distributions, please take a look at the metadata.json.
@@ -345,53 +345,32 @@ yum::plugin { 'versionlock':
   ensure => present,
 }
 ```
+The module must be included to purge any unmanaged versionlock files on the system.
 
 ### Lock a package with the *versionlock* plugin
-The `versionlock` type changed between CentOS 7 and CentOS 8.
 
-#### CentOS 7 and older
-Locks explicitly specified packages from updates. Package name must be precisely
-specified in format *`EPOCH:NAME-VERSION-RELEASE.ARCH`*. Wild card in package
-name is allowed provided it does not span a field seperator.
+Specify the version and some of the release, epoch or arch values as parameters.
 
 ```puppet
-yum::versionlock { '0:bash-4.1.2-9.el6_2.*':
-  ensure => present,
+yum::versionlock{'bash':
+  ensure  => present,
+  version => '4.1.2',
+  release => '9.el8.2.*',
+  epoch   => 0,
+  arch    => 'x86_64',
 }
 ```
 
-Use the following command to retrieve a properly-formated string:
-
-```sh
-PACKAGE_NAME='bash'
-rpm -q "$PACKAGE_NAME" --qf '%|EPOCH?{%{EPOCH}}:{0}|:%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n'
-```
-
-To run a `yum clean all` after the versionlock file is updated.
+To run a `dnf clean all` after the versionlock file is updated.
 
 ```puppet
 class{'yum::plugin::versionlock':
   clean => true,
 }
-yum::versionlock { '0:bash-4.1.2-9.el6_2.*':
-  ensure => present,
-}
-```
-
-Note the CentOS 8 mechansim can be used if the parameter
-`version` is also set to anything other than the default `undef`. This allows
-common code to be used on CentOS  7 and 8 if the new style is used.
-
-#### CentOS 8 and newer
-Specify some of the version, release, epoch and arch values as parameters.
-
-```puppet
-yum::versionlock{'bash':
+yum::versionlock { 'bash':
   ensure => present,
   version => '4.1.2',
-  release => '9.el8.2.*',
-  epoch   => 0,
-  arch    => 'x86_64',
+  release => '9.el9_2',
 }
 ```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -343,6 +343,8 @@ Data type: `String`
 
 filepath for the versionlock.list, default based on your system.
 
+Default value: `'/etc/dnf/plugins/versionlock.list'`
+
 ### <a name="yum--settings"></a>`yum::settings`
 
 Simple settings to use
@@ -747,50 +749,18 @@ The command to run
 
 Locks package from updates.
 
-* **Note** The resource title must use the format
-By default on CentOS 7 the following format is used.
-"%{EPOCH}:%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}".  This can be retrieved via
-the command `rpm -q --qf '%{EPOCH}:%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}'.
-If "%{EPOCH}" returns as '(none)', it should be set to '0'.  Wildcards may
-be used within token slots, but must not cover seperators, e.g.,
-'0:b*sh-4.1.2-9.*' covers Bash version 4.1.2, revision 9 on all
-architectures.
-By default on CentOS 8 and newer the resource title  to just set the
-package name.
-If a version is set on CentOS 7 then it behaves like CentOS 8
-
 * **See also**
-  * http://man7.org/linux/man-pages/man1/yum-versionlock.1.html
+  * https://dnf-plugins-core.readthedocs.io/en/latest/versionlock.html
 
 #### Examples
 
-##### Sample usage on CentOS 7
-
-```puppet
-yum::versionlock { '0:bash-4.1.2-9.el7.*':
-  ensure => present,
-}
-```
-
-##### Sample usage on CentOS 8
+##### Sample usage
 
 ```puppet
 yum::versionlock { 'bash':
   ensure => present,
   version => '4.1.2',
   release => '9.el8',
-  epoch   => 0,
-  arch    => 'noarch',
-}
-```
-
-##### Sample usage on CentOS 7 with new style version, release, epoch, name parameters.
-
-```puppet
-yum::versionlock { 'bash':
-  ensure => present,
-  version => '3.1.2',
-  release => '9.el7',
   epoch   => 0,
   arch    => 'noarch',
 }
@@ -805,6 +775,7 @@ The following parameters are available in the `yum::versionlock` defined type:
 * [`release`](#-yum--versionlock--release)
 * [`arch`](#-yum--versionlock--arch)
 * [`epoch`](#-yum--versionlock--epoch)
+* [`package`](#-yum--versionlock--package)
 
 ##### <a name="-yum--versionlock--ensure"></a>`ensure`
 
@@ -818,8 +789,7 @@ Default value: `'present'`
 
 Data type: `Optional[Yum::RpmVersion]`
 
-Version of the package if CentOS 8 mechanism is used. This must be set for dnf based systems (e.g CentOS 8).
-If version is set then the name var is assumed to a package name and not the full versionlock string.
+Version of the package
 
 Default value: `undef`
 
@@ -827,7 +797,7 @@ Default value: `undef`
 
 Data type: `Yum::RpmRelease`
 
-Release of the package if CentOS 8 mechanism is used.
+Release of the package
 
 Default value: `'*'`
 
@@ -835,7 +805,7 @@ Default value: `'*'`
 
 Data type: `Variant[Yum::RpmArch, Enum['*']]`
 
-Arch of the package if CentOS 8 mechanism is used.
+Arch of the package
 
 Default value: `'*'`
 
@@ -843,9 +813,17 @@ Default value: `'*'`
 
 Data type: `Variant[Integer[0], Pattern[/^[1-9]\d*$/]]`
 
-Epoch of the package if CentOS 8 mechanism is used.
+Epoch of the package
 
 Default value: `0`
+
+##### <a name="-yum--versionlock--package"></a>`package`
+
+Data type: `Yum::RpmNameGlob`
+
+The package name or package glob
+
+Default value: `$title`
 
 ## Resource types
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -19,5 +19,4 @@ lookup_options:
     merge: 'unique'
 
 # Default is currently yum path
-yum::plugin::versionlock::path: /etc/yum/pluginconf.d/versionlock.list
 yum::settings::mainconf: /etc/yum.conf

--- a/data/package_provider/dnf.yaml
+++ b/data/package_provider/dnf.yaml
@@ -1,3 +1,2 @@
 ---
-yum::plugin::versionlock::path: /etc/dnf/plugins/versionlock.list
 yum::settings::mainconf:        /etc/dnf/dnf.conf

--- a/manifests/plugin/versionlock.pp
+++ b/manifests/plugin/versionlock.pp
@@ -11,19 +11,13 @@
 #   }
 #
 class yum::plugin::versionlock (
-  String                    $path,
-  Enum['present', 'absent'] $ensure   = 'present',
-  Boolean                   $clean    = false,
+  Enum['present', 'absent'] $ensure = 'present',
+  String $path = '/etc/dnf/plugins/versionlock.list',
+  Boolean $clean = false,
 ) {
-  $pkg_prefix = $facts['package_provider'] ? {
-    'dnf'   => 'python3-dnf-plugin',
-    'yum'   => 'yum-plugin',
-    default => '',
-  }
-
   yum::plugin { 'versionlock':
     ensure     => $ensure,
-    pkg_prefix => $pkg_prefix,
+    pkg_prefix => 'python3-dnf-plugin',
   }
 
   if $ensure == 'present' {

--- a/manifests/versionlock.pp
+++ b/manifests/versionlock.pp
@@ -1,11 +1,6 @@
 # @summary Locks package from updates.
 #
-# @example Sample usage on CentOS 7
-#   yum::versionlock { '0:bash-4.1.2-9.el7.*':
-#     ensure => present,
-#   }
-#
-# @example Sample usage on CentOS 8
+# @example Sample usage
 #   yum::versionlock { 'bash':
 #     ensure => present,
 #     version => '4.1.2',
@@ -14,52 +9,32 @@
 #     arch    => 'noarch',
 #   }
 #
+# @param ensure Specifies if versionlock should be `present`, `absent` or `exclude`.
 #
-# @example Sample usage on CentOS 7 with new style version, release, epoch, name parameters.
-#   yum::versionlock { 'bash':
-#     ensure => present,
-#     version => '3.1.2',
-#     release => '9.el7',
-#     epoch   => 0,
-#     arch    => 'noarch',
-#   }
+# @param version Version of the package
 #
-# @param ensure
-#   Specifies if versionlock should be `present`, `absent` or `exclude`.
+# @param release Release of the package
 #
-# @param version
-#   Version of the package if CentOS 8 mechanism is used. This must be set for dnf based systems (e.g CentOS 8).
-#   If version is set then the name var is assumed to a package name and not the full versionlock string.
+# @param arch Arch of the package
 #
-# @param release
-#   Release of the package if CentOS 8 mechanism is used.
+# @param epoch Epoch of the package
 #
-# @param arch
-#   Arch of the package if CentOS 8 mechanism is used.
+# @param package The package name or package glob
 #
-# @param epoch
-#   Epoch of the package if CentOS 8 mechanism is used.
+# @see https://dnf-plugins-core.readthedocs.io/en/latest/versionlock.html
 #
-# @note The resource title must use the format
-#   By default on CentOS 7 the following format is used.
-#   "%{EPOCH}:%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}".  This can be retrieved via
-#   the command `rpm -q --qf '%{EPOCH}:%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}'.
-#   If "%{EPOCH}" returns as '(none)', it should be set to '0'.  Wildcards may
-#   be used within token slots, but must not cover seperators, e.g.,
-#   '0:b*sh-4.1.2-9.*' covers Bash version 4.1.2, revision 9 on all
-#   architectures.
-#   By default on CentOS 8 and newer the resource title  to just set the
-#   package name.
-#   If a version is set on CentOS 7 then it behaves like CentOS 8
-#
-# @see http://man7.org/linux/man-pages/man1/yum-versionlock.1.html
 define yum::versionlock (
   Enum['present', 'absent', 'exclude']       $ensure  = 'present',
   Optional[Yum::RpmVersion]                  $version = undef,
   Yum::RpmRelease                            $release = '*',
   Variant[Integer[0], Pattern[/^[1-9]\d*$/]] $epoch   = 0,
   Variant[Yum::RpmArch, Enum['*']]           $arch    = '*',
+  Yum::RpmNameGlob                           $package = $title,
 ) {
+  if $ensure in ['present', 'exclude'] and ! $version {
+    fail('The version parameter must be set when ensure is present or exclude')
+  }
+
   require yum::plugin::versionlock
 
   $line_prefix = $ensure ? {
@@ -67,28 +42,7 @@ define yum::versionlock (
     default   => '',
   }
 
-  if $facts['package_provider'] == 'yum' and $version =~ Undef {
-    assert_type(Yum::VersionlockString, $name) |$_expected, $actual | {
-      # lint:ignore:140chars
-      fail("Package name must be formatted as %{EPOCH}:%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}, not \'${actual}\'. See Yum::Versionlock documentation for details.")
-      # lint:endignore
-    }
-
-    $_versionlock = "${line_prefix}${name}"
-  } else {
-    assert_type(Yum::RpmNameGlob, $name) |$_expected, $actual | {
-      fail("Package name must be formatted as Yum::RpmName, not \'${actual}\'. See Yum::Rpmname documentation for details.")
-    }
-
-    assert_type(Yum::RpmVersion, $version) |$_expected, $actual | {
-      fail("Version must be formatted as Yum::RpmVersion, not \'${actual}\'. See Yum::RpmVersion documentation for details.")
-    }
-
-    $_versionlock = $facts['package_provider'] ? {
-      'yum'   => "${line_prefix}${epoch}:${name}-${version}-${release}.${arch}",
-      default => "${line_prefix}${name}-${epoch}:${version}-${release}.${arch}",
-    }
-  }
+  $_versionlock = "${line_prefix}${name}-${epoch}:${version}-${release}.${arch}"
 
   unless $ensure == 'absent' {
     concat::fragment { "yum-versionlock-${name}":

--- a/spec/acceptance/define_versionlock_spec.rb
+++ b/spec/acceptance/define_versionlock_spec.rb
@@ -7,26 +7,17 @@ describe 'yum::versionlock define' do
     # Using puppet_apply as a helper
     it 'must work idempotently with no errors' do
       pp = <<-EOS
-      if versioncmp($facts['os']['release']['major'],'7') <= 0 {
-        yum::versionlock{ '0:bash-4.1.2-9.el6_2.*':
-          ensure => present,
-        }
-        yum::versionlock{ '0:tcsh-3.1.2-9.el6_2.*':
-          ensure => present,
-        }
-      } else {
-        yum::versionlock{ 'bash':
-          ensure  => present,
-          version => '4.1.2',
-          release => '9.el6_2',
-        }
-        yum::versionlock{ 'tcsh':
-          ensure  => present,
-          version => '3.1.2',
-          release => '9.el6_2',
-          arch    => '*',
-          epoch   => 0,
-        }
+      yum::versionlock{ 'bash':
+        ensure  => present,
+        version => '4.1.2',
+        release => '9.el6_2',
+      }
+      yum::versionlock{ 'tcsh':
+        ensure  => present,
+        version => '3.1.2',
+        release => '9.el6_2',
+        arch    => '*',
+        epoch   => 0,
       }
 
       # Lock a package with new style on all OSes
@@ -44,51 +35,30 @@ describe 'yum::versionlock define' do
       apply_manifest(pp, catch_changes:  true)
     end
 
-    if fact('os.release.major') == '7'
-      describe file('/etc/yum/pluginconf.d/versionlock.list') do
-        it { is_expected.to be_file }
-        it { is_expected.to contain '0:bash-4.1.2-9.el6_2.*' }
-        it { is_expected.to contain '0:tcsh-3.1.2-9.el6_2.*' }
-        it { is_expected.to contain '2:netscape-8.1.2-9.el6_2.*' }
-      end
-    else
-      describe file('/etc/dnf/plugins/versionlock.list') do
-        it { is_expected.to be_file }
+    describe file('/etc/dnf/plugins/versionlock.list') do
+      it { is_expected.to be_file }
 
-        it { is_expected.to contain 'bash-0:4.1.2-9.el6_2.*' }
-        it { is_expected.to contain 'tcsh-0:3.1.2-9.el6_2.*' }
-        it { is_expected.to contain 'netscape-2:8.1.2-9.el6_2.*' }
-      end
+      it { is_expected.to contain 'bash-0:4.1.2-9.el6_2.*' }
+      it { is_expected.to contain 'tcsh-0:3.1.2-9.el6_2.*' }
+      it { is_expected.to contain 'netscape-2:8.1.2-9.el6_2.*' }
     end
 
-    if fact('os.release.major') == '7'
-      describe package('yum-plugin-versionlock') do
-        it { is_expected.to be_installed }
-      end
-    else
-      describe package('python3-dnf-plugin-versionlock') do
-        it { is_expected.to be_installed }
-      end
+    describe package('python3-dnf-plugin-versionlock') do
+      it { is_expected.to be_installed }
     end
   end
 
   it 'must work if clean is specified' do
-    shell('yum repolist', acceptable_exit_codes: [0])
+    shell('dnf repolist', acceptable_exit_codes: [0])
     pp = <<-EOS
     class{yum::plugin::versionlock:
       clean => true,
     }
-    # Pick an obscure package that hopefully will not be installed.
-    if versioncmp($facts['os']['release']['major'],'7') <= 0 {
-      yum::versionlock{ '0:samba-devel-3.1.2-9.el6_2.*':
-        ensure  => present,
-      }
-    } else {
-      yum::versionlock{'samba-devel':
-        ensure  => present,
-        version => '3.1.2',
-        release => '9.el6_2',
-      }
+    # Lock a package that exists but the version will not exist.
+    yum::versionlock{'samba-common':
+      ensure  => present,
+      version => '3.1.2',
+      release => '9.el6_2',
     }
     EOS
     # Run it twice and test for idempotency
@@ -97,14 +67,6 @@ describe 'yum::versionlock define' do
 
     # Check the cache is really empty.
     # all repos will have 0 packages.
-    # bit confused by the motivation of the first test?
-    if fact('os.release.major') == '7'
-      shell('yum -C repolist -d0 | grep -v "repo id"  | awk "{print $NF}" FS=  | grep -v 0', acceptable_exit_codes: [1])
-      shell('yum -q list available samba-devel', acceptable_exit_codes: [1])
-    elsif %w[8 9].include?(fact('os.release.major'))
-      shell('dnf -q list --available samba-devel', acceptable_exit_codes: [1])
-    else
-      shell('dnf install -y samba-devel | grep "All matches were filtered"', acceptable_exit_codes: [0])
-    end
+    shell('dnf install -y samba-common | grep "All matches were filtered"', acceptable_exit_codes: [0])
   end
 end

--- a/spec/classes/plugin_versionlock_spec.rb
+++ b/spec/classes/plugin_versionlock_spec.rb
@@ -5,42 +5,26 @@ require 'spec_helper'
 describe 'yum::plugin::versionlock' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      %w[yum dnf].each do |provider|
-        context "with package_provider #{provider}" do
-          let(:facts) do
-            os_facts.merge(package_provider: provider)
-          end
+      let(:facts) do
+        os_facts
+      end
 
-          it { is_expected.to compile.with_all_deps }
+      it { is_expected.to compile.with_all_deps }
 
-          case provider
-          when 'yum'
-            it { is_expected.to contain_package('yum-plugin-versionlock').with_ensure('present') }
-            it { is_expected.not_to contain_package('python3-dnf-plugin-versionlock') }
-            it { is_expected.to contain_concat__fragment('versionlock_header').with_target('/etc/yum/pluginconf.d/versionlock.list') }
-          else
-            it { is_expected.to contain_package('python3-dnf-plugin-versionlock').with_ensure('present') }
-            it { is_expected.not_to contain_package('yum-plugin-versionlock') }
-            it { is_expected.to contain_concat__fragment('versionlock_header').with_target('/etc/dnf/plugins/versionlock.list') }
-          end
-          context 'with plugin disable' do
-            let(:params) do
-              { ensure: 'absent' }
-            end
+      it { is_expected.to contain_package('python3-dnf-plugin-versionlock').with_ensure('present') }
+      it { is_expected.not_to contain_package('yum-plugin-versionlock') }
+      it { is_expected.to contain_concat__fragment('versionlock_header').with_target('/etc/dnf/plugins/versionlock.list') }
 
-            it { is_expected.to compile.with_all_deps }
-            it { is_expected.not_to contain_concat__fragment('versionlock_header') }
-
-            case provider
-            when 'yum'
-              it { is_expected.to contain_package('yum-plugin-versionlock').with_ensure('absent') }
-              it { is_expected.not_to contain_package('python3-dnf-plugin-versionlock') }
-            else
-              it { is_expected.to contain_package('python3-dnf-plugin-versionlock').with_ensure('absent') }
-              it { is_expected.not_to contain_package('yum-plugin-versionlock') }
-            end
-          end
+      context 'with plugin disable' do
+        let(:params) do
+          { ensure: 'absent' }
         end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.not_to contain_concat__fragment('versionlock_header') }
+
+        it { is_expected.to contain_package('python3-dnf-plugin-versionlock').with_ensure('absent') }
+        it { is_expected.not_to contain_package('yum-plugin-versionlock') }
       end
     end
   end

--- a/spec/defines/versionlock_spec.rb
+++ b/spec/defines/versionlock_spec.rb
@@ -3,136 +3,70 @@
 require 'spec_helper'
 
 describe 'yum::versionlock' do
-  context 'with package_provider set to yum' do
-    let(:facts) do
-      { os: { release: { major: 7 } },
-        package_provider: 'yum' }
-    end
+  # old deprecated yum EL7 style
+  context 'with the old style yum strings 0:bash-4.1.2-9.el6_2.x86_64' do
+    let(:title) { '0:bash-4.1.2-9.el6_2.x86_64' }
 
-    context 'with a simple, well-formed title 0:bash-4.1.2-9.el6_2.x86_64' do
-      let(:title) { '0:bash-4.1.2-9.el6_2.x86_64' }
-
-      context 'and no parameters' do
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_concat__fragment('versionlock_header').with_content("# File managed by puppet\n") }
-
-        it 'contains a well-formed Concat::Fragment' do
-          is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("#{title}\n")
-        end
-
-        it { is_expected.to contain_concat('/etc/yum/pluginconf.d/versionlock.list').without_notify }
-      end
-
-      context 'clean set to true on module' do
-        let :pre_condition do
-          'class { "yum::plugin::versionlock": clean => true, }'
-        end
-
-        it { is_expected.to contain_concat('/etc/yum/pluginconf.d/versionlock.list').with_notify('Exec[yum_clean_all]') }
-        it { is_expected.to contain_exec('yum_clean_all').with_command('/usr/bin/yum clean all') }
-      end
-
-      context 'and ensure set to present' do
-        let(:params) { { ensure: 'present' } }
-
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_concat__fragment('versionlock_header').with_content("# File managed by puppet\n") }
-
-        it 'contains a well-formed Concat::Fragment' do
-          is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("#{title}\n")
-        end
-      end
-
-      context 'and ensure set to absent' do
-        let(:params) { { ensure: 'absent' } }
-
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_concat__fragment('versionlock_header').with_content("# File managed by puppet\n") }
-
-        it 'contains a well-formed Concat::Fragment' do
-          is_expected.not_to contain_concat__fragment("yum-versionlock-#{title}")
-        end
-      end
-
-      context 'with version set namevar must be just a package name' do
-        let(:params) { { version: '4.3' } }
-
-        it { is_expected.to compile.and_raise_error(%r{Package name must be formatted as Yum::RpmName, not 'String'}) }
-      end
-    end
-
-    context 'with a trailing wildcard title' do
-      let(:title) { '0:bash-4.1.2-9.el6_2.*' }
-
-      it { is_expected.to compile.with_all_deps }
-
-      it 'contains a well-formed Concat::Fragment' do
-        is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("#{title}\n")
-      end
-    end
-
-    context 'with a complex wildcard title' do
-      let(:title) { '0:bash-4.*-*.el6' }
-
-      it 'contains a well-formed Concat::Fragment' do
-        is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("#{title}\n")
-      end
-    end
-
-    context 'with a release containing dots' do
-      let(:title) { '1:java-1.7.0-openjdk-1.7.0.121-2.6.8.0.el7_3.x86_64' }
-
-      it 'contains a well-formed Concat::Fragment' do
-        is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("#{title}\n")
-      end
-    end
-
-    context 'with an invalid title' do
-      let(:title) { 'bash-4.1.2' }
-
-      it { is_expected.to compile.and_raise_error(%r(%\{EPOCH\}:%\{NAME\}-%\{VERSION\}-%\{RELEASE\}\.%\{ARCH\})) }
-    end
-
-    context 'with an invalid wildcard pattern' do
-      let(:title) { '0:bash-4.1.2*' }
-
-      it { is_expected.to compile.and_raise_error(%r(%\{EPOCH\}:%\{NAME\}-%\{VERSION\}-%\{RELEASE\}\.%\{ARCH\})) }
-    end
+    it { is_expected.to compile.and_raise_error(%r{expects a match for Yum::RpmNameGlob}) }
   end
 
-  context 'with a simple, well-formed package name title bash and a version' do
-    let(:facts) do
-      { os: { release: { major: 7 } },
-        package_provider: 'yum' }
-    end
-
+  context 'with a simple, well-formed package name' do
     let(:title) { 'bash' }
-    let(:params) { { version: '4.3' } }
 
-    context 'with version set' do
-      it { is_expected.to compile.with_all_deps }
+    it { is_expected.to compile.and_raise_error(%r{The version parameter must be set}) }
 
-      it 'contains a well-formed Concat::Fragment' do
-        is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("0:bash-4.3-*.*\n")
+    context 'with ensure absent' do
+      let(:params) { { ensure: 'absent' } }
+
+      it 'does not contain a well-formed Concat::Fragment' do
+        is_expected.not_to contain_concat__fragment('yum-versionlock-bash')
       end
     end
 
-    context 'with version, release, epoch and arch set as strings' do
+    context 'and a version set to 4.3' do
+      let(:params) { { version: '4.3' } }
+
+      it 'contains a well-formed Concat::Fragment' do
+        is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-0:4.3-*.*\n")
+      end
+
+      context 'and an arch set to x86_64' do
+        let(:params)  { super().merge(arch: 'x86_64') }
+
+        it 'contains a well-formed Concat::Fragment' do
+          is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-0:4.3-*.x86_64\n")
+        end
+      end
+
+      context 'and an release set to 22.x' do
+        let(:params) { super().merge(release: '22.5') }
+
+        it 'contains a well-formed Concat::Fragment' do
+          is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-0:4.3-22.5.*\n")
+        end
+      end
+
+      context 'and an epoch set to 5' do
+        let(:params) { super().merge(epoch: 5) }
+
+        it 'contains a well-formed Concat::Fragment' do
+          is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-5:4.3-*.*\n")
+        end
+      end
+    end
+
+    context 'with release, version, epoch, arch all set' do
       let(:params) do
         {
-          version: '4.3',
-          release: '3.2',
-          arch: 'arm',
-          epoch: '42'
+          version: '22.5',
+          release: 'alpha12',
+          epoch: 8,
+          arch: 'i386'
         }
       end
 
-      context 'it works' do
-        it { is_expected.to compile.with_all_deps }
-
-        it 'contains a well-formed Concat::Fragment' do
-          is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("42:bash-4.3-3.2.arm\n")
-        end
+      it 'contains a well-formed Concat::Fragment' do
+        is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-8:22.5-alpha12.i386\n")
       end
     end
 
@@ -150,83 +84,22 @@ describe 'yum::versionlock' do
         it { is_expected.to compile.with_all_deps }
 
         it 'contains a well-formed Concat::Fragment' do
-          is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("42:bash-4.3-3.2.arm\n")
+          is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("bash-42:4.3-3.2.arm\n")
         end
       end
     end
   end
 
-  context 'with package_provider set to dnf' do
-    let(:facts) do
-      { os: { release: { major: 8 } },
-        package_provider: 'dnf' }
+  context 'with a globby package name' do
+    let(:title) { 'tcsh*' }
+    let(:params) do
+      {
+        version: 4.3,
+      }
     end
-
-    context 'with a simple, well-formed title, no version set' do
-      let(:title) { 'bash' }
-
-      it { is_expected.to compile.and_raise_error(%r{Version must be formatted as Yum::RpmVersion}) }
-
-      context 'and a version set to 4.3' do
-        let(:params) { { version: '4.3' } }
-
-        it 'contains a well-formed Concat::Fragment' do
-          is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-0:4.3-*.*\n")
-        end
-
-        context 'and an arch set to x86_64' do
-          let(:params)  { super().merge(arch: 'x86_64') }
-
-          it 'contains a well-formed Concat::Fragment' do
-            is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-0:4.3-*.x86_64\n")
-          end
-        end
-
-        context 'and an release set to 22.x' do
-          let(:params) { super().merge(release: '22.5') }
-
-          it 'contains a well-formed Concat::Fragment' do
-            is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-0:4.3-22.5.*\n")
-          end
-        end
-
-        context 'and an epoch set to 5' do
-          let(:params) { super().merge(epoch: 5) }
-
-          it 'contains a well-formed Concat::Fragment' do
-            is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-5:4.3-*.*\n")
-          end
-        end
-      end
-
-      context 'with release, version, epoch, arch all set' do
-        let(:params) do
-          {
-            version: '22.5',
-            release: 'alpha12',
-            epoch: 8,
-            arch: 'i386'
-          }
-        end
-
-        it 'contains a well-formed Concat::Fragment' do
-          is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-8:22.5-alpha12.i386\n")
-        end
-      end
-    end
-  end
-
-  context 'with package_provider unset' do
-    let(:facts) do
-      { os: { release: { major: 7 } } }
-    end
-    let(:title) { 'bash' }
-    let(:params) { { version: '4.3' } }
-
-    it { is_expected.to compile.with_all_deps }
 
     it 'contains a well-formed Concat::Fragment' do
-      is_expected.to contain_concat__fragment('yum-versionlock-bash').with_content("bash-0:4.3-*.*\n")
+      is_expected.to contain_concat__fragment("yum-versionlock-#{title}").with_content("tcsh*-0:4.3-*.*\n")
     end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description

Since introduction of dnf with EL8 `yum::versionlock` users have been forced to migrate to the new paramatised `yum::versionlock` introduced in #169 puppet-yum v4.2.0.

EL7 support was already removed with #353

This patch cleans up the dual mode of `yum::versionlock` and now only dnf systems are supported.

The old method will now fail for all OSes, previous to this patch it only failed on EL8 and EL9.
Reminder 
* On EL7 the epoch is at start of string inside `versionlock.list`
* On EL8++ the epoch is in the middle of the string inside `versionlock.list`.

It is now impossible to create EL7 yum compatible versionlock files with this module.

* Puppet 7 support removal https://github.com/voxpupuli/puppet-yum/pull/353
* Introduction of paramatised versionlock: https://github.com/voxpupuli/puppet-yum/pull/169
