### PR TITLE
Replace deprecated `egrep` with `grep -E`

### DIFF
--- a/manifests/copr.pp
+++ b/manifests/copr.pp
@@ -32,21 +32,21 @@ define yum::copr (
       'enabled': {
         exec { "dnf -y copr enable ${copr_repo}":
           path    => '/bin:/usr/bin:/sbin/:/usr/sbin',
-          unless  => "dnf copr list | egrep -q '${copr_name}\$'",
+          unless  => "dnf copr list | grep -Eq '${copr_name}\$'",
           require => Package[$prereq_plugin],
         }
       }
       'disabled': {
         exec { "dnf -y copr disable ${copr_repo}":
           path    => '/bin:/usr/bin:/sbin/:/usr/sbin',
-          unless  => "dnf copr list | egrep -q '${copr_name} \\(disabled\\)\$'",
+          unless  => "dnf copr list | grep -Eq '${copr_name} \\(disabled\\)\$'",
           require => Package[$prereq_plugin],
         }
       }
       'removed': {
         exec { "dnf -y copr remove ${copr_repo}":
           path    => '/bin:/usr/bin:/sbin/:/usr/sbin',
-          onlyif  => "dnf copr list | egrep -q '${copr_name}'",
+          onlyif  => "dnf copr list | grep -Eq '${copr_name}'",
           require => Package[$prereq_plugin],
         }
       }

--- a/manifests/group.pp
+++ b/manifests/group.pp
@@ -24,7 +24,7 @@ define yum::group (
     'present', default: { # just install the yum group and ensure the group is present.
       exec { "yum-groupinstall-${name}":
         command => join(concat(["yum -y group install '${name}'"], $install_options), ' '),
-        unless  => "yum grouplist hidden '${name}' | egrep -i '^Installed.+Groups:$'",
+        unless  => "yum grouplist hidden '${name}' | grep -Ei '^Installed.+Groups:$'",
         timeout => $timeout,
       }
     }
@@ -45,7 +45,7 @@ define yum::group (
     'absent', 'purged': {
       exec { "yum-groupremove-${name}":
         command => "yum -y group remove '${name}'",
-        onlyif  => "yum grouplist hidden '${name}' | egrep -i '^Installed.+Groups:$'",
+        onlyif  => "yum grouplist hidden '${name}' | grep -Ei '^Installed.+Groups:$'",
         timeout => $timeout,
       }
     }

--- a/spec/defines/copr_spec.rb
+++ b/spec/defines/copr_spec.rb
@@ -81,7 +81,7 @@ describe 'yum::copr' do
       it {
         is_expected.to contain_exec("dnf -y copr enable #{title}").with(
           'path'    => '/bin:/usr/bin:/sbin/:/usr/sbin',
-          'unless'  => "dnf copr list | egrep -q '#{title}$'",
+          'unless'  => "dnf copr list | grep -Eq '#{title}$'",
           'require' => "Package[#{prereq_plugin}]",
         )
       }
@@ -95,7 +95,7 @@ describe 'yum::copr' do
       it {
         is_expected.to contain_exec("dnf -y copr disable #{title}").with(
           'path'    => '/bin:/usr/bin:/sbin/:/usr/sbin',
-          'unless'  => "dnf copr list | egrep -q '#{title} \\(disabled\\)$'",
+          'unless'  => "dnf copr list | grep -Eq '#{title} \\(disabled\\)$'",
           'require' => "Package[#{prereq_plugin}]",
         )
       }
@@ -109,7 +109,7 @@ describe 'yum::copr' do
       it {
         is_expected.to contain_exec("dnf -y copr remove #{title}").with(
           'path'    => '/bin:/usr/bin:/sbin/:/usr/sbin',
-          'onlyif'  => "dnf copr list | egrep -q '#{title}'",
+          'onlyif'  => "dnf copr list | grep -Eq '#{title}'",
           'require' => "Package[#{prereq_plugin}]",
         )
       }


### PR DESCRIPTION
This replaces egrep with grep -E, since sooner or later egrep won't work anymore.