### PR TITLE
Add onlyif to package cleanup so it doesn't error if there's nothing to remove.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -239,10 +239,16 @@ class yum (
     default => "/usr/bin/dnf -y remove $(/usr/bin/dnf repoquery --installonly --latest-limit=-${_real_installonly_limit}${_keep_kernel_devel} | /usr/bin/grep -v ${facts['kernelrelease']})"
   }
 
+  $_pc_onlyif = $facts['package_provider'] ? {
+    'yum'   => undef,
+    default => "/usr/bin/dnf repoquery --installonly --latest-limit=-${_real_installonly_limit}${_keep_kernel_devel} | /usr/bin/grep -v ${facts['kernelrelease']}",
+  }
+
   exec { 'package-cleanup_oldkernels':
     command     => $_pc_cmd,
     refreshonly => true,
     require     => Package[$utils_package_name],
+    onlyif      => $_pc_onlyif,
     subscribe   => $_clean_old_kernels_subscribe,
   }
 


### PR DESCRIPTION
#### Pull Request (PR) description
At least on dnf5 if you call dnf remove without specifying packages you get this error:

Missing positional argument "specs" for command "remove". Add "--help" for more information about the arguments.

To that end add an onlyif to the package cleanup so if repoquery returns no packages we don't do anything.

#### This Pull Request (PR) fixes the following issues
Fixes #383 