### PR TITLE
Add new `yumrepo_metadata_key` type

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -26,6 +26,7 @@
 ### Resource types
 
 * [`dnf_module_stream`](#dnf_module_stream): Manage DNF module streams
+* [`yumrepo_metadata_key`](#yumrepo_metadata_key): Manage a GPG key in a repository's metadata keystore (repo_gpgcheck=1).
 
 ### Functions
 
@@ -921,6 +922,71 @@ usually discover the appropriate provider for your platform.
 Valid values: `%r{.+}`
 
 Resource title
+
+### <a name="yumrepo_metadata_key"></a>`yumrepo_metadata_key`
+
+Manage a GPG key in a repository's metadata keystore (repo_gpgcheck=1).
+Title must be "<repo>:<fingerprint>", identified by the PRIMARY fingerprint.
+
+`repo` and `fingerprint` are derived from the title and should not be set
+independently.
+
+#### Examples
+
+##### Add a key for the `updates` repository
+
+```puppet
+yumrepo_metadata_key { 'updates:3B49DF2A0F5E6E4F7A1B2C3D4E5F60718293A4B5':
+  ensure  => present,
+  content => file('profile/gpg_metadata_keys/updates.key'),
+}
+```
+
+#### Properties
+
+The following properties are available in the `yumrepo_metadata_key` type.
+
+##### `content`
+
+ASCII-armored public key.
+
+##### `ensure`
+
+Valid values: `present`, `absent`
+
+The basic property that the resource should be in.
+
+Default value: `present`
+
+#### Parameters
+
+The following parameters are available in the `yumrepo_metadata_key` type.
+
+* [`fingerprint`](#-yumrepo_metadata_key--fingerprint)
+* [`name`](#-yumrepo_metadata_key--name)
+* [`provider`](#-yumrepo_metadata_key--provider)
+* [`repo`](#-yumrepo_metadata_key--repo)
+
+##### <a name="-yumrepo_metadata_key--fingerprint"></a>`fingerprint`
+
+Primary fingerprint (derived from the title).
+
+##### <a name="-yumrepo_metadata_key--name"></a>`name`
+
+namevar
+
+Composed as "<repo>:<fingerprint>".
+
+Default value: `''`
+
+##### <a name="-yumrepo_metadata_key--provider"></a>`provider`
+
+The specific backend to use for this `yumrepo_metadata_key` resource. You will seldom need to specify this --- Puppet
+will usually discover the appropriate provider for your platform.
+
+##### <a name="-yumrepo_metadata_key--repo"></a>`repo`
+
+Repository id (derived from the title).
 
 ## Functions
 

--- a/lib/puppet/provider/yumrepo_metadata_key.rb
+++ b/lib/puppet/provider/yumrepo_metadata_key.rb
@@ -1,0 +1,233 @@
+# frozen_string_literal: true
+
+require 'digest'
+require 'fileutils'
+require 'tempfile'
+require 'tmpdir'
+
+class Puppet::Provider::YumrepoMetadataKey < Puppet::Provider
+  class << self
+    # Concrete providers must implement these to locate a repo's keystore(s):
+    #   live_homes       -> [[repo, home], ...] for the current 'live' keystores
+    #   all_homes_for    -> [home, ...] every keystore for repo (destroy sweep)
+    def live_homes
+      raise NotImplementedError, "#{self} must implement .live_homes"
+    end
+
+    def all_homes_for(_repo)
+      raise NotImplementedError, "#{self} must implement .all_homes_for"
+    end
+
+    def instances
+      ret = live_homes.flat_map do |repo, home|
+        next [] unless File.directory?(home) # home may not exist yet if dnf hasn't populated the cache for this repo
+
+        primary_fingerprints_in(home).map do |fpr|
+          new(ensure: :present, name: "#{repo}:#{fpr}", repo: repo, fingerprint: fpr,
+              home: home, content: export_key(home, fpr))
+        end
+      end
+      debug("instances -> #{ret.map(&:name).inspect}")
+      ret
+    end
+
+    def prefetch(resources)
+      instances.each do |prov|
+        res = resources[prov.name]
+        res.provider = prov if res
+      end
+    end
+
+    def primary_fingerprints_in(home)
+      ret = parse_primary_fprs(gpg_at(home, '--with-colons', '--fingerprint', '--list-keys')).uniq
+      debug("primary_fingerprints_in(#{home.inspect}) -> #{ret.inspect}")
+      ret
+    rescue Puppet::ExecutionFailure => e
+      debug("primary_fingerprints_in(#{home.inspect}) failed: #{e.message.lines.first.to_s.strip}")
+      []
+    end
+
+    # gpg --with-colons emits a `pub:` record for each primary key immediately
+    # followed by its `fpr:` record (fingerprint in field 10). Pair adjacent
+    # records and keep the fpr after each `pub:`, ignoring `sub:` (subkey) fprs.
+    def parse_primary_fprs(text)
+      text.lines.map { |line| line.split(':') }.each_cons(2).filter_map do |record, next_record|
+        next_record[9] if record[0] == 'pub' && next_record[0] == 'fpr'
+      end
+    end
+
+    def extract_armored_key(text, context)
+      match = text.to_s.match(%r{-----BEGIN PGP PUBLIC KEY BLOCK-----.*?-----END PGP PUBLIC KEY BLOCK-----}m)
+      unless match
+        warning("#{context} did not contain an armored public key: #{text.to_s.lines.first.to_s.strip}") unless text.to_s.strip.empty?
+        return nil
+      end
+
+      extra = text.to_s.sub(match[0], '').strip
+      warning("#{context} included unexpected output: #{extra.lines.first.to_s.strip}") unless extra.empty?
+      "#{match[0]}\n"
+    end
+
+    # Armored public key for `fingerprint` from the keystore at `home`, or
+    # nil if the home is missing or the key can't be exported.
+    def export_key(home, fingerprint)
+      return unless home && File.directory?(home)
+
+      out =
+        begin
+          gpg_at(home, '--export', '--armor', fingerprint)
+        rescue Puppet::ExecutionFailure
+          ''
+        end
+      extract_armored_key(out, "gpg export for #{fingerprint}")
+    end
+
+    # Canonicalise a key so semantically-equal keys hash equally: import `text`
+    # into a throwaway keyring, re-export it --armor, and SHA256 the result.
+    # This normalises armor formatting/packet ordering and captures expiry and
+    # subkey changes that a raw compare of the supplied ASCII would miss.
+    def canonical_key_digest(text)
+      ret = Dir.mktmpdir do |tmp|
+        keyfile = File.join(tmp, 'k.asc')
+        File.write(keyfile, text)
+        gpg_at(tmp, '--import', keyfile)
+        primary = parse_primary_fprs(gpg_at(tmp, '--with-colons', '--fingerprint', '--list-keys')).first
+        exported = primary && export_key(tmp, primary)
+        exported ? Digest::SHA256.hexdigest(exported) : nil
+      rescue Puppet::ExecutionFailure => e
+        debug("canonical_key_digest failed: #{e.message.lines.first.to_s.strip}")
+        nil
+      end
+      debug("canonical_key_digest -> #{ret.inspect}")
+      ret
+    end
+
+    def primary_fpr_of_content(text)
+      ret = Dir.mktmpdir do |tmp|
+        keyfile = File.join(tmp, 'k.asc')
+        File.write(keyfile, text)
+        parse_primary_fprs(gpg_at(tmp, *show_keys_args(keyfile))).first
+      end
+      debug("primary_fpr_of_content -> #{ret.inspect}")
+      ret
+    end
+
+    def ultimate_trust?(home, fingerprint)
+      ret = gpg_at(home, '--export-ownertrust').each_line.any? do |line|
+        fields = line.chomp.split(':')
+        fields[0].to_s.upcase == fingerprint.to_s.upcase && fields[1] == '6'
+      end
+      debug("ultimate_trust?(#{home.inspect}, #{fingerprint.inspect}) -> #{ret.inspect}")
+      ret
+    rescue Puppet::ExecutionFailure => e
+      debug("ultimate_trust?(#{home.inspect}, #{fingerprint.inspect}) failed: #{e.message.lines.first.to_s.strip}")
+      false
+    end
+
+    def set_ultimate_trust(home, fingerprint)
+      Tempfile.create(['metakey-ownertrust', '.txt']) do |f|
+        f.write("#{fingerprint}:6:\n")
+        f.flush
+        gpg_at(home, '--import-ownertrust', f.path)
+      end
+    end
+
+    def url_hash(source)
+      Digest::SHA256.digest(source)[0, 8].unpack1('H*')
+    end
+
+    def gpg_at(home, *args)
+      gpg('--homedir', home, *gpg_common_flags, *args)
+    end
+
+    def gpg_common_flags
+      ['--batch', '--no-tty', '--no-autostart', '--no-permission-warning']
+    end
+
+    def show_keys_args(path)
+      ['--with-colons', '--show-keys', path]
+    end
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    import_key(resource[:content])
+    @property_hash[:ensure] = :present
+  end
+
+  # Deletes the key not only in the 'live' keystore, but also in any others than might exist (from eg. when the baseurl for a repo was different)
+  def destroy
+    homes = self.class.all_homes_for(resource[:repo])
+    debug("destroy sweeping #{resource[:fingerprint]} across #{homes.inspect}")
+    homes.each do |home|
+      next unless File.directory?(home)
+
+      begin
+        # --expert bypasses gpg's pre-delete check for a matching secret key.
+        # That check needs gpg-agent, but --no-autostart forbids starting one,
+        # so without --expert, --delete-keys fails with "no gpg-agent running".
+        self.class.gpg_at(home, '--expert', '--yes', '--delete-keys', resource[:fingerprint])
+        debug("destroy removed #{resource[:fingerprint]} from #{home.inspect}")
+      rescue Puppet::ExecutionFailure => e
+        debug("destroy skipped #{home.inspect}: #{e.message.lines.first.to_s.strip}")
+      end
+    end
+    @property_hash[:ensure] = :absent
+  end
+
+  def content
+    @property_hash[:content] || :absent
+  end
+
+  def content=(value)
+    debug("content= re-importing #{resource[:fingerprint]}")
+    import_key(value)
+  end
+
+  def ultimate_trust?
+    home = live_home
+    home && self.class.ultimate_trust?(home, resource[:fingerprint])
+  end
+
+  # NOTE: mk_resource_methods can't be used here. It needs a type-bound
+  # provider (this abstract parent has resource_type == nil), and running it in
+  # the concrete providers would regenerate a `content=` that just writes
+  # @property_hash, clobbering our importing content= below. These trivial
+  # getters are the mk_resource_methods equivalent, written by hand.
+  def repo
+    @property_hash[:repo]
+  end
+
+  def fingerprint
+    @property_hash[:fingerprint]
+  end
+
+  private
+
+  def import_key(text)
+    raise Puppet::Error, 'content is required when ensure => present' if text.nil? || text == :absent
+
+    dir = live_home
+    raise Puppet::Error, "cannot locate live keystore for repo '#{resource[:repo]}'" unless dir
+
+    Tempfile.create(['metakey', '.asc']) do |f|
+      f.write(text)
+      f.flush
+
+      primary = self.class.primary_fpr_of_content(text)
+      raise Puppet::Error, "fingerprint #{resource[:fingerprint]} is not the primary of the supplied key (primary is #{primary})" if primary && primary != resource[:fingerprint]
+
+      FileUtils.mkdir_p(dir, mode: 0o700)
+      debug("import_key #{resource[:fingerprint]} -> #{dir.inspect}")
+      self.class.gpg_at(dir, '--import', f.path)
+      self.class.set_ultimate_trust(dir, resource[:fingerprint])
+    end
+  end
+
+  def live_home
+    @live_home ||= @property_hash[:home] || self.class.live_homes.to_h[resource[:repo]]
+  end
+end

--- a/lib/puppet/provider/yumrepo_metadata_key/dnf4.rb
+++ b/lib/puppet/provider/yumrepo_metadata_key/dnf4.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require_relative '../yumrepo_metadata_key'
+
+Puppet::Type.type(:yumrepo_metadata_key).provide(:dnf4, parent: Puppet::Provider::YumrepoMetadataKey) do
+  desc 'dnf4/libdnf metadata keystore under /var/cache/dnf (EL8/EL9).'
+
+  commands gpg: 'gpg', dnf: 'dnf'
+  confine    'os.family': 'RedHat'
+  defaultfor 'os.family': 'RedHat', 'os.release.major': %w[8 9]
+
+  class << self
+    def live_homes
+      ret = repo_sources.map do |repo, source|
+        [repo, File.join(cache_base, "#{repo}-#{url_hash(source)}", 'pubring')]
+      end
+      debug("live_homes -> #{ret.inspect}")
+      ret
+    end
+
+    def all_homes_for(repo)
+      ret = Dir.glob(File.join(cache_base, "#{repo}-*", 'pubring')).select do |home|
+        File.basename(File.dirname(home)) =~ %r{\A#{Regexp.escape(repo)}-\h{16}\z} && File.directory?(home)
+      end
+      debug("all_homes_for(#{repo.inspect}) -> #{ret.inspect}")
+      ret
+    end
+
+    private
+
+    def cache_base
+      '/var/cache/dnf'
+    end
+
+    # Returns the path to dnf's own Python interpreter, named on its first line,
+    # e.g. "#!/usr/libexec/platform-python".
+    def dnf_python
+      first_line = File.open(command(:dnf), &:readline)
+      interpreter = first_line[%r{\A#!\s*(\S+)}, 1]
+      interpreter || '/usr/bin/python3'
+    rescue StandardError
+      '/usr/bin/python3'
+    end
+
+    # Maps each configured repo id to the URL dnf derives its cache directory
+    # from (metalink, else mirrorlist, else first baseurl, else the id itself),
+    # asked of python3-dnf so we read exactly what libdnf resolved. live_homes
+    # hashes this URL the same way libdnf does to locate the repo's keystore.
+    def repo_sources
+      script = <<~PY
+        import dnf
+        b = dnf.Base()
+        b.read_all_repos()
+        for r in b.repos.values():
+            src = r.metalink or r.mirrorlist or (r.baseurl[0] if r.baseurl else r.id)
+            print("%s\\t%s" % (r.id, src))
+      PY
+      out = Puppet::Util::Execution.execute([dnf_python, '-c', script], failonfail: true).to_s
+      ret = out.each_line.filter_map do |line|
+        id, src = line.chomp.split("\t", 2)
+        [id, src] if id && src && !src.empty?
+      end
+      debug("repo_sources -> #{ret.inspect}")
+      ret
+    rescue Puppet::ExecutionFailure => e
+      debug("repo_sources failed: #{e.message.lines.first.to_s.strip}")
+      []
+    end
+  end
+end

--- a/lib/puppet/provider/yumrepo_metadata_key/yum.rb
+++ b/lib/puppet/provider/yumrepo_metadata_key/yum.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require_relative '../yumrepo_metadata_key'
+
+Puppet::Type.type(:yumrepo_metadata_key).provide(:yum, parent: Puppet::Provider::YumrepoMetadataKey) do
+  desc 'yum-3 per-repo gpgdir (EL7).'
+
+  commands gpg: 'gpg', yum: 'yum'
+  confine    'os.family': 'RedHat'
+  defaultfor 'os.family': 'RedHat', 'os.release.major': '7'
+
+  class << self
+    def live_homes
+      ret = gpgdirs.map { |home| [File.basename(File.dirname(home)), home] }
+      debug("live_homes -> #{ret.inspect}")
+      ret
+    end
+
+    def all_homes_for(repo)
+      ret = gpgdirs.select { |home| File.basename(File.dirname(home)) == repo }
+      debug("all_homes_for(#{repo.inspect}) -> #{ret.inspect}")
+      ret
+    end
+
+    # EL7's gpg predates --no-autostart, so drop it from the parent's flags.
+    def gpg_common_flags
+      super - ['--no-autostart']
+    end
+
+    def show_keys_args(path)
+      ['--with-colons', '--with-fingerprint', path]
+    end
+
+    private
+
+    # yum keeps per-repo gpgdirs under both /var/lib/yum (persistent state) and
+    # /var/cache/yum (cache); a repo's keystore can appear in either, so scan both.
+    def gpgdirs
+      ret = Dir.glob('/var/lib/yum/repos/*/*/*/gpgdir') + Dir.glob('/var/cache/yum/*/*/*/gpgdir')
+      debug("gpgdirs -> #{ret.inspect}")
+      ret
+    end
+  end
+end

--- a/lib/puppet/type/yumrepo_metadata_key.rb
+++ b/lib/puppet/type/yumrepo_metadata_key.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+Puppet::Type.newtype(:yumrepo_metadata_key) do
+  @doc = <<~DOC
+    @summary Manage a GPG key in a repository's metadata keystore (repo_gpgcheck=1).
+
+    Manage a GPG key in a repository's metadata keystore (repo_gpgcheck=1).
+    Title must be "<repo>:<fingerprint>", identified by the PRIMARY fingerprint.
+
+    @example Add a key for the `updates` repository
+      yumrepo_metadata_key { 'updates:3B49DF2A0F5E6E4F7A1B2C3D4E5F60718293A4B5':
+        ensure  => present,
+        content => file('profile/gpg_metadata_keys/updates.key'),
+      }
+
+    `repo` and `fingerprint` are derived from the title and should not be set
+    independently.
+  DOC
+
+  ensurable do
+    newvalue(:present) do
+      @resource.provider.create
+      nil
+    end
+
+    newvalue(:absent) do
+      @resource.provider.destroy
+      nil
+    end
+
+    defaultto :present
+  end
+
+  def self.title_patterns
+    [
+      [
+        %r{\A(.+):(\h{40})\z}i,
+        [
+          [:repo, ->(x) { x }],
+          [:fingerprint, ->(x) { x.delete(' ').upcase }],
+        ],
+      ],
+    ]
+  end
+
+  newparam(:repo, namevar: true) do
+    desc 'Repository id (derived from the title).'
+    validate do |value|
+      raise ArgumentError, 'repo must not be empty' if value.to_s.empty?
+    end
+  end
+
+  newparam(:fingerprint, namevar: true) do
+    desc 'Primary fingerprint (derived from the title).'
+    validate do |value|
+      raise ArgumentError, "fingerprint must be 40 hex characters, got #{value.inspect}" unless value.to_s.delete(' ') =~ %r{\A\h{40}\z}
+    end
+    munge { |value| value.to_s.delete(' ').upcase }
+  end
+
+  newparam(:name, namevar: true) do
+    desc 'Composed as "<repo>:<fingerprint>".'
+    defaultto ''
+    munge { |value| value.to_s.empty? ? "#{resource[:repo]}:#{resource[:fingerprint]}" : value }
+  end
+
+  newproperty(:content) do
+    desc 'ASCII-armored public key.'
+
+    # Compare canonical key material, so expiry and subkey changes are detected.
+    def insync?(is)
+      return false if is.nil? || is == :absent
+
+      # Force updating of key if ownertrust isn't set correctly
+      unless provider.ultimate_trust?
+        debug('content insync? -> false (ownertrust is not ultimate)')
+        return false
+      end
+
+      current_digest = provider.class.canonical_key_digest(is)
+      desired_digest = provider.class.canonical_key_digest(should)
+      ret = !current_digest.nil? && current_digest == desired_digest
+      debug("content insync? -> #{ret}")
+      ret
+    end
+
+    # Keys are public, not secret, but full armored blocks make change notices
+    # noisy and multi-line, so render concise summaries instead.
+    def should_to_s(_newvalue)
+      "key for #{resource[:fingerprint]}"
+    end
+
+    def is_to_s(currentvalue)
+      (currentvalue == :absent) ? 'absent' : "#{currentvalue.to_s.bytesize} bytes armored"
+    end
+  end
+
+  autorequire(:yumrepo) { [self[:repo]] }
+end

--- a/spec/acceptance/yumrepo_metadata_key_spec.rb
+++ b/spec/acceptance/yumrepo_metadata_key_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+# Install a repo's metadata-signing key, then install a package from that repo with repo_gpgcheck=1
+describe 'yumrepo_metadata_key' do
+  let(:signed_repos) do
+    {
+      'Rocky' => {
+        '8' => {
+          repo: 'baseos',
+          baseurl: 'https://dl.rockylinux.org/vault/rocky/8.9/BaseOS/x86_64/os/',
+          keyfile: '/etc/pki/rpm-gpg/RPM-GPG-KEY-rockyofficial',
+          fingerprint: '7051C470A929F454CEBE37B715AF5DAC6D745A60',
+          package: 'zip',
+        },
+        '9' => {
+          repo: 'baseos',
+          baseurl: 'https://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/',
+          keyfile: '/etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9',
+          fingerprint: '21CB256AE16FC54C6E652949702D426D350D275D',
+          package: 'zip',
+        },
+      },
+      'AlmaLinux' => {
+        '8' => {
+          repo: 'baseos',
+          baseurl: 'https://repo.almalinux.org/almalinux/8/BaseOS/x86_64/os/',
+          keyfile: '/etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux',
+          key_index: 1, # this file bundles two keys; the signer is the second
+          fingerprint: 'BC5EDDCADF502C077F1582882AE81E8ACED7258B',
+          package: 'zip',
+        },
+        '9' => {
+          repo: 'baseos',
+          baseurl: 'https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os/',
+          keyfile: '/etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-9',
+          fingerprint: 'BF18AC2876178908D6E71267D36CB86CB86B3716',
+          package: 'zip',
+        },
+      },
+      'CentOS' => {
+        '9' => {
+          repo: 'baseos',
+          baseurl: 'https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/',
+          keyfile: '/etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial',
+          fingerprint: '99DB70FAE1D7CE227FB6488205B555B38483C65D',
+          package: 'zip',
+        },
+      },
+      # Oracle Linux does not sign its base metadata, so test against a signed third-party repo (Docker CE) instead.
+      'OracleLinux' => {
+        '8' => {
+          repo: 'docker',
+          baseurl: 'https://download.docker.com/linux/centos/8/x86_64/stable/',
+          key_url: 'https://download.docker.com/linux/centos/gpg',
+          fingerprint: '060A61C51B558A7F742B77AAC52FEB6B621E9F35',
+          package: 'docker-compose-plugin',
+        },
+        '9' => {
+          repo: 'docker',
+          baseurl: 'https://download.docker.com/linux/centos/9/x86_64/stable/',
+          key_url: 'https://download.docker.com/linux/centos/gpg',
+          fingerprint: '060A61C51B558A7F742B77AAC52FEB6B621E9F35',
+          package: 'docker-compose-plugin',
+        },
+      },
+    }
+  end
+
+  it 'installs a repo metadata-signing key and verifies signed metadata end to end' do
+    os_name = fact('os.name')
+    major = fact('os.release.major')
+    repo = signed_repos.dig(os_name, major)
+    skip "no known signed repo for #{os_name} #{major}" unless repo
+
+    title = "#{repo[:repo]}:#{repo[:fingerprint]}"
+
+    keyfile = repo[:keyfile]
+    if repo[:key_url]
+      keyfile = '/tmp/yumrepo_metadata_key_acceptance.asc'
+      shell("curl -sfL '#{repo[:key_url]}' -o #{keyfile}")
+    end
+
+    shell("dnf remove -y #{repo[:package]} || true")
+    shell('dnf clean all')
+
+    pp = <<~PUPPET
+      # Purge stock repos so the cache dir (and keystore path) is deterministic.
+      resources { 'yumrepo':
+        purge  => true,
+        before => Package[#{repo[:package]}],
+      }
+
+      # Some keyfiles bundle several keys; keep only the block we manage.
+      $blocks = split(file('#{keyfile}'), /(?=-----BEGIN PGP PUBLIC KEY BLOCK-----)/).filter |$b| { $b =~ /BEGIN PGP/ }
+
+      # Declared first on purpose: autorequire must still order it after the repo.
+      yumrepo_metadata_key { '#{title}':
+        ensure  => present,
+        content => $blocks[#{repo.fetch(:key_index, 0)}],
+      }
+
+      yumrepo { '#{repo[:repo]}':
+        descr         => '#{repo[:repo]} (acceptance test)',
+        baseurl       => '#{repo[:baseurl]}',
+        enabled       => 1,
+        repo_gpgcheck => 1, # verified only against the keystore our type fills
+        gpgcheck      => 0, # package sigs out of scope
+      }
+
+      package { '#{repo[:package]}':
+        ensure  => installed,
+        require => Yumrepo_metadata_key['#{title}'],
+      }
+    PUPPET
+
+    apply_manifest(pp, catch_failures: true)
+    apply_manifest(pp, catch_changes: true)
+
+    keys = shell(%(for h in /var/cache/dnf/#{repo[:repo]}-*/pubring; do gpg --homedir "$h" --list-keys --with-colons; done)).stdout
+    expect(keys).to match(repo[:fingerprint])
+    expect(shell("rpm -q #{repo[:package]}", acceptable_exit_codes: [0, 1]).exit_code).to eq(0)
+  end
+end

--- a/spec/unit/puppet/type/yumrepo_metadata_key_spec.rb
+++ b/spec/unit/puppet/type/yumrepo_metadata_key_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../../fixtures/modules/yumrepo_core/lib/puppet/type/yumrepo'
+
+describe Puppet::Type.type(:yumrepo_metadata_key) do
+  let(:resource_name) { 'baseos:21CB256AE16FC54C6E652949702D426D350D275D' }
+
+  def new_resource(attributes = {})
+    described_class.new({ name: resource_name }.merge(attributes))
+  end
+
+  it 'loads' do
+    expect(described_class).not_to be_nil
+  end
+
+  describe 'namevars' do
+    it 'has 3 namevars' do
+      expect(described_class.key_attributes.size).to eq(3)
+    end
+
+    %i[name repo fingerprint].each do |param|
+      it "'#{param}' is a namevar" do
+        expect(described_class.key_attributes).to include(param)
+      end
+    end
+  end
+
+  describe 'ensure' do
+    it 'is ensurable' do
+      expect(described_class.attrtype(:ensure)).to eq(:property)
+    end
+
+    it 'accepts present' do
+      expect(new_resource(ensure: :present)[:ensure]).to eq(:present)
+    end
+
+    it 'accepts absent' do
+      expect(new_resource(ensure: :absent)[:ensure]).to eq(:absent)
+    end
+
+    it 'rejects other values' do
+      expect { new_resource(ensure: :installed) }.to raise_error(%r{Invalid value :installed\. Valid values are present, absent})
+    end
+  end
+
+  describe 'title' do
+    it 'is rejected without a 40-character fingerprint' do
+      expect { described_class.new(name: 'baseos:nothex') }.to raise_error(%r{No set of title patterns matched})
+    end
+  end
+
+  describe 'repo' do
+    it 'is set from resource title' do
+      expect(new_resource[:repo]).to eq('baseos')
+    end
+  end
+
+  describe 'fingerprint' do
+    it 'is set from resource title' do
+      expect(new_resource[:fingerprint]).to eq('21CB256AE16FC54C6E652949702D426D350D275D')
+    end
+
+    it 'is upcased' do
+      expect(described_class.new(name: 'baseos:21cb256ae16fc54c6e652949702d426d350d275d')[:fingerprint]).to eq('21CB256AE16FC54C6E652949702D426D350D275D')
+    end
+  end
+
+  describe 'content' do
+    it 'is a property' do
+      expect(described_class.attrtype(:content)).to eq(:property)
+    end
+
+    it 'accepts an armored key string' do
+      expect(new_resource(content: 'ARMORED KEY')[:content]).to eq('ARMORED KEY')
+    end
+  end
+
+  describe 'autorequire' do
+    let(:catalog) { Puppet::Resource::Catalog.new }
+    let(:repo) { Puppet::Type.type(:yumrepo).new(name: 'baseos') }
+    let(:yumrepo_metadata_key_resource) { new_resource }
+
+    it 'autorequires the yum repo' do
+      catalog.add_resource(repo)
+      catalog.add_resource(yumrepo_metadata_key_resource)
+
+      relationships = yumrepo_metadata_key_resource.autorequire
+
+      expect(relationships.map(&:source)).to include(repo)
+      expect(relationships.map(&:target)).to include(yumrepo_metadata_key_resource)
+    end
+  end
+end


### PR DESCRIPTION
Add new type for managing a repo's _metadata_ gpg public keys. These keys are separate to the package signing keys that the `yum::gpgkey` defined type can manage.

Initial implementation supports EL 7, EL8 and EL 9. To support EL10, a `dnf5` provider will probably be required.

Fixes #385

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>