### PR TITLE
Add `dnf5` support to `yumrepo_metadata_key`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -928,6 +928,9 @@ Resource title
 Manage a GPG key in a repository's metadata keystore (repo_gpgcheck=1).
 Title must be "<repo>:<fingerprint>", identified by the PRIMARY fingerprint.
 
+On systems running `dnf` version `5`, `python3-libdnf5` must be installed before
+this type can be used.
+
 `repo` and `fingerprint` are derived from the title and should not be set
 independently.
 

--- a/lib/facter/dnf_version.rb
+++ b/lib/facter/dnf_version.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Facter.add(:dnf_version) do
+  confine package_provider: 'dnf'
+  setcode do
+    dnf = Facter::Util::Resolution.which('dnf')
+    next unless dnf
+
+    output = Facter::Core::Execution.execute("#{dnf} --version", on_fail: nil)
+    match = output&.match(%r{^(?:dnf\d+ version )?(?<full>(?<major>\d+)(?:\.\d+)+)})
+    next unless match
+
+    { 'full' => match[:full], 'major' => match[:major] }
+  end
+end

--- a/lib/puppet/feature/libdnf5.rb
+++ b/lib/puppet/feature/libdnf5.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# True once python3 can import libdnf5
+Puppet.features.add(:libdnf5) do
+  Puppet::Util::Execution.execute(['python3', '-c', 'import libdnf5'], failonfail: false).exitstatus.zero? || nil
+rescue StandardError
+  nil
+end

--- a/lib/puppet/provider/yumrepo_metadata_key.rb
+++ b/lib/puppet/provider/yumrepo_metadata_key.rb
@@ -7,22 +7,46 @@ require 'tmpdir'
 
 class Puppet::Provider::YumrepoMetadataKey < Puppet::Provider
   class << self
-    # Concrete providers must implement these to locate a repo's keystore(s):
-    #   live_homes       -> [[repo, home], ...] for the current 'live' keystores
-    #   all_homes_for    -> [home, ...] every keystore for repo (destroy sweep)
+    # @return [Array<Array(String, String)>] `[repo, home]` per configured repo. A
+    #   home may not exist yet; dnf only creates it on first fetch.
     def live_homes
       raise NotImplementedError, "#{self} must implement .live_homes"
     end
 
+    # Includes stale homes from a repo's previous source URL, which `destroy` sweeps too.
+    # @return [Array<String>] every home a repo's keys could be in
     def all_homes_for(_repo)
       raise NotImplementedError, "#{self} must implement .all_homes_for"
+    end
+
+    # @return [Array<String>] fingerprint of each primary key in `home`, ignoring subkeys
+    def fingerprints_in(_home)
+      raise NotImplementedError, "#{self} must implement .fingerprints_in"
+    end
+
+    # @return [String, nil] the stored key, or nil if absent
+    def export_key(_home, _fingerprint)
+      raise NotImplementedError, "#{self} must implement .export_key"
+    end
+
+    def store_key(_home, _fingerprint, _text)
+      raise NotImplementedError, "#{self} must implement .store_key"
+    end
+
+    def remove_key(_home, _fingerprint)
+      raise NotImplementedError, "#{self} must implement .remove_key"
+    end
+
+    # @return [Boolean] whether the key is present and trusted to verify metadata
+    def trusted?(_home, _fingerprint)
+      raise NotImplementedError, "#{self} must implement .trusted?"
     end
 
     def instances
       ret = live_homes.flat_map do |repo, home|
         next [] unless File.directory?(home) # home may not exist yet if dnf hasn't populated the cache for this repo
 
-        primary_fingerprints_in(home).map do |fpr|
+        fingerprints_in(home).map do |fpr|
           new(ensure: :present, name: "#{repo}:#{fpr}", repo: repo, fingerprint: fpr,
               home: home, content: export_key(home, fpr))
         end
@@ -36,15 +60,6 @@ class Puppet::Provider::YumrepoMetadataKey < Puppet::Provider
         res = resources[prov.name]
         res.provider = prov if res
       end
-    end
-
-    def primary_fingerprints_in(home)
-      ret = parse_primary_fprs(gpg_at(home, '--with-colons', '--fingerprint', '--list-keys')).uniq
-      debug("primary_fingerprints_in(#{home.inspect}) -> #{ret.inspect}")
-      ret
-    rescue Puppet::ExecutionFailure => e
-      debug("primary_fingerprints_in(#{home.inspect}) failed: #{e.message.lines.first.to_s.strip}")
-      []
     end
 
     # gpg --with-colons emits a `pub:` record for each primary key immediately
@@ -68,20 +83,6 @@ class Puppet::Provider::YumrepoMetadataKey < Puppet::Provider
       "#{match[0]}\n"
     end
 
-    # Armored public key for `fingerprint` from the keystore at `home`, or
-    # nil if the home is missing or the key can't be exported.
-    def export_key(home, fingerprint)
-      return unless home && File.directory?(home)
-
-      out =
-        begin
-          gpg_at(home, '--export', '--armor', fingerprint)
-        rescue Puppet::ExecutionFailure
-          ''
-        end
-      extract_armored_key(out, "gpg export for #{fingerprint}")
-    end
-
     # Canonicalise a key so semantically-equal keys hash equally: import `text`
     # into a throwaway keyring, re-export it --armor, and SHA256 the result.
     # This normalises armor formatting/packet ordering and captures expiry and
@@ -92,7 +93,7 @@ class Puppet::Provider::YumrepoMetadataKey < Puppet::Provider
         File.write(keyfile, text)
         gpg_at(tmp, '--import', keyfile)
         primary = parse_primary_fprs(gpg_at(tmp, '--with-colons', '--fingerprint', '--list-keys')).first
-        exported = primary && export_key(tmp, primary)
+        exported = primary && gpg_export_armored(tmp, primary)
         exported ? Digest::SHA256.hexdigest(exported) : nil
       rescue Puppet::ExecutionFailure => e
         debug("canonical_key_digest failed: #{e.message.lines.first.to_s.strip}")
@@ -112,28 +113,18 @@ class Puppet::Provider::YumrepoMetadataKey < Puppet::Provider
       ret
     end
 
-    def ultimate_trust?(home, fingerprint)
-      ret = gpg_at(home, '--export-ownertrust').each_line.any? do |line|
-        fields = line.chomp.split(':')
-        fields[0].to_s.upcase == fingerprint.to_s.upcase && fields[1] == '6'
-      end
-      debug("ultimate_trust?(#{home.inspect}, #{fingerprint.inspect}) -> #{ret.inspect}")
-      ret
-    rescue Puppet::ExecutionFailure => e
-      debug("ultimate_trust?(#{home.inspect}, #{fingerprint.inspect}) failed: #{e.message.lines.first.to_s.strip}")
-      false
-    end
-
-    def set_ultimate_trust(home, fingerprint)
-      Tempfile.create(['metakey-ownertrust', '.txt']) do |f|
-        f.write("#{fingerprint}:6:\n")
-        f.flush
-        gpg_at(home, '--import-ownertrust', f.path)
-      end
-    end
-
     def url_hash(source)
       Digest::SHA256.digest(source)[0, 8].unpack1('H*')
+    end
+
+    def gpg_export_armored(home, fingerprint)
+      out =
+        begin
+          gpg_at(home, '--export', '--armor', fingerprint)
+        rescue Puppet::ExecutionFailure
+          ''
+        end
+      extract_armored_key(out, "gpg export for #{fingerprint}")
     end
 
     def gpg_at(home, *args)
@@ -166,10 +157,7 @@ class Puppet::Provider::YumrepoMetadataKey < Puppet::Provider
       next unless File.directory?(home)
 
       begin
-        # --expert bypasses gpg's pre-delete check for a matching secret key.
-        # That check needs gpg-agent, but --no-autostart forbids starting one,
-        # so without --expert, --delete-keys fails with "no gpg-agent running".
-        self.class.gpg_at(home, '--expert', '--yes', '--delete-keys', resource[:fingerprint])
+        self.class.remove_key(home, resource[:fingerprint])
         debug("destroy removed #{resource[:fingerprint]} from #{home.inspect}")
       rescue Puppet::ExecutionFailure => e
         debug("destroy skipped #{home.inspect}: #{e.message.lines.first.to_s.strip}")
@@ -187,9 +175,9 @@ class Puppet::Provider::YumrepoMetadataKey < Puppet::Provider
     import_key(value)
   end
 
-  def ultimate_trust?
+  def trusted?
     home = live_home
-    home && self.class.ultimate_trust?(home, resource[:fingerprint])
+    home && self.class.trusted?(home, resource[:fingerprint])
   end
 
   # NOTE: mk_resource_methods can't be used here. It needs a type-bound
@@ -213,18 +201,12 @@ class Puppet::Provider::YumrepoMetadataKey < Puppet::Provider
     dir = live_home
     raise Puppet::Error, "cannot locate live keystore for repo '#{resource[:repo]}'" unless dir
 
-    Tempfile.create(['metakey', '.asc']) do |f|
-      f.write(text)
-      f.flush
+    primary = self.class.primary_fpr_of_content(text)
+    raise Puppet::Error, "fingerprint #{resource[:fingerprint]} is not the primary of the supplied key (primary is #{primary})" if primary && primary != resource[:fingerprint]
 
-      primary = self.class.primary_fpr_of_content(text)
-      raise Puppet::Error, "fingerprint #{resource[:fingerprint]} is not the primary of the supplied key (primary is #{primary})" if primary && primary != resource[:fingerprint]
-
-      FileUtils.mkdir_p(dir, mode: 0o700)
-      debug("import_key #{resource[:fingerprint]} -> #{dir.inspect}")
-      self.class.gpg_at(dir, '--import', f.path)
-      self.class.set_ultimate_trust(dir, resource[:fingerprint])
-    end
+    FileUtils.mkdir_p(dir, mode: 0o700)
+    debug("import_key #{resource[:fingerprint]} -> #{dir.inspect}")
+    self.class.store_key(dir, resource[:fingerprint], text)
   end
 
   def live_home

--- a/lib/puppet/provider/yumrepo_metadata_key/dnf4.rb
+++ b/lib/puppet/provider/yumrepo_metadata_key/dnf4.rb
@@ -6,8 +6,9 @@ Puppet::Type.type(:yumrepo_metadata_key).provide(:dnf4, parent: Puppet::Provider
   desc 'dnf4/libdnf metadata keystore under /var/cache/dnf (EL8/EL9).'
 
   commands gpg: 'gpg', dnf: 'dnf'
-  confine    'os.family': 'RedHat'
-  defaultfor 'os.family': 'RedHat', 'os.release.major': %w[8 9]
+  confine    package_provider: 'dnf'
+  confine    'dnf_version.major': '4'
+  defaultfor package_provider: 'dnf'
 
   class << self
     def live_homes

--- a/lib/puppet/provider/yumrepo_metadata_key/dnf4.rb
+++ b/lib/puppet/provider/yumrepo_metadata_key/dnf4.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative '../yumrepo_metadata_key'
+require_relative 'gpg_keyring'
 
-Puppet::Type.type(:yumrepo_metadata_key).provide(:dnf4, parent: Puppet::Provider::YumrepoMetadataKey) do
+Puppet::Type.type(:yumrepo_metadata_key).provide(:dnf4, parent: Puppet::Provider::YumrepoMetadataKey::GpgKeyring) do
   desc 'dnf4/libdnf metadata keystore under /var/cache/dnf (EL8/EL9).'
 
   commands gpg: 'gpg', dnf: 'dnf'

--- a/lib/puppet/provider/yumrepo_metadata_key/dnf5.rb
+++ b/lib/puppet/provider/yumrepo_metadata_key/dnf5.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require_relative '../yumrepo_metadata_key'
+
+Puppet::Type.type(:yumrepo_metadata_key).provide(:dnf5, parent: Puppet::Provider::YumrepoMetadataKey) do
+  desc 'dnf5/libdnf5 metadata keystore under /var/cache/libdnf5 (Fedora 43+, EL11+).'
+
+  commands gpg: 'gpg', dnf: 'dnf'
+  confine    package_provider: 'dnf'
+  confine    'dnf_version.major': '5'
+  confine    feature: :libdnf5
+  defaultfor package_provider: 'dnf'
+
+  # dnf5 stores each key as an armored <LONGKEYID>.pub file, looked up by that
+  # exact filename. No GnuPG keyring or ownertrust; a present file is trusted.
+  class << self
+    def live_homes
+      ret = repo_cachedirs.map { |repo, cachedir| [repo, File.join(cachedir, 'pubring')] }
+      debug("live_homes -> #{ret.inspect}")
+      ret
+    end
+
+    def all_homes_for(repo)
+      ret = Dir.glob(File.join(cache_base, "#{repo}-*", 'pubring')).select do |home|
+        File.basename(File.dirname(home)) =~ %r{\A#{Regexp.escape(repo)}-\h{16}\z} && File.directory?(home)
+      end
+      debug("all_homes_for(#{repo.inspect}) -> #{ret.inspect}")
+      ret
+    end
+
+    def fingerprints_in(home)
+      ret = Dir.glob(File.join(home, '*.pub')).filter_map { |file| primary_fpr_of_content(File.read(file)) }.uniq
+      debug("fingerprints_in(#{home.inspect}) -> #{ret.inspect}")
+      ret
+    end
+
+    def export_key(home, fingerprint)
+      return unless home && File.directory?(home)
+
+      file = pub_file(home, fingerprint)
+      File.file?(file) ? File.read(file) : nil
+    end
+
+    def store_key(home, fingerprint, text)
+      file = pub_file(home, fingerprint)
+      File.write(file, extract_armored_key(text, "content for #{fingerprint}") || text)
+      debug("store_key #{fingerprint} -> #{file.inspect}")
+    end
+
+    def remove_key(home, fingerprint)
+      file = pub_file(home, fingerprint)
+      File.delete(file) if File.file?(file)
+    end
+
+    def trusted?(_home, _fingerprint)
+      true
+    end
+
+    private
+
+    def pub_file(home, fingerprint)
+      File.join(home, "#{long_keyid(fingerprint)}.pub")
+    end
+
+    def long_keyid(fingerprint)
+      fingerprint.to_s.delete(' ').upcase[-16, 16]
+    end
+
+    def cache_base
+      '/var/cache/libdnf5'
+    end
+
+    # Ask libdnf5 for each configured repo's resolved cache directory. get_cachedir
+    # already encodes the base dir and the per-repo hash, so live_homes points at
+    # exactly the directory dnf5 will populate, even before it has been created.
+    def repo_cachedirs
+      script = <<~PY
+        import libdnf5
+        base = libdnf5.base.Base()
+        base.load_config()
+        base.setup()
+        sack = base.get_repo_sack()
+        sack.create_repos_from_system_configuration()
+        for repo in libdnf5.repo.RepoQuery(base):
+            print("%s\\t%s" % (repo.get_id(), repo.get_cachedir()))
+      PY
+      out = Puppet::Util::Execution.execute(['python3', '-c', script], failonfail: true).to_s
+      ret = out.each_line.filter_map do |line|
+        id, dir = line.chomp.split("\t", 2)
+        [id, dir] if id && dir && !dir.empty?
+      end
+      debug("repo_cachedirs -> #{ret.inspect}")
+      ret
+    rescue Puppet::ExecutionFailure => e
+      debug("repo_cachedirs failed: #{e.message.lines.first.to_s.strip}")
+      []
+    end
+  end
+end

--- a/lib/puppet/provider/yumrepo_metadata_key/gpg_keyring.rb
+++ b/lib/puppet/provider/yumrepo_metadata_key/gpg_keyring.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require_relative '../yumrepo_metadata_key'
+
+# Backend parent for providers that keep keys in a per-repo GnuPG homedir (yum and dnf4).
+class Puppet::Provider::YumrepoMetadataKey::GpgKeyring < Puppet::Provider::YumrepoMetadataKey
+  class << self
+    def fingerprints_in(home)
+      ret = parse_primary_fprs(gpg_at(home, '--with-colons', '--fingerprint', '--list-keys')).uniq
+      debug("fingerprints_in(#{home.inspect}) -> #{ret.inspect}")
+      ret
+    rescue Puppet::ExecutionFailure => e
+      debug("fingerprints_in(#{home.inspect}) failed: #{e.message.lines.first.to_s.strip}")
+      []
+    end
+
+    def export_key(home, fingerprint)
+      return unless home && File.directory?(home)
+
+      gpg_export_armored(home, fingerprint)
+    end
+
+    def store_key(home, fingerprint, text)
+      Tempfile.create(['metakey', '.asc']) do |f|
+        f.write(text)
+        f.flush
+        gpg_at(home, '--import', f.path)
+        set_ultimate_trust(home, fingerprint)
+      end
+    end
+
+    # --expert bypasses gpg's pre-delete check for a matching secret key.
+    # That check needs gpg-agent, but --no-autostart forbids starting one,
+    # so without --expert, --delete-keys fails with "no gpg-agent running".
+    def remove_key(home, fingerprint)
+      gpg_at(home, '--expert', '--yes', '--delete-keys', fingerprint)
+    end
+
+    def trusted?(home, fingerprint)
+      ret = gpg_at(home, '--export-ownertrust').each_line.any? do |line|
+        fields = line.chomp.split(':')
+        fields[0].to_s.upcase == fingerprint.to_s.upcase && fields[1] == '6'
+      end
+      debug("trusted?(#{home.inspect}, #{fingerprint.inspect}) -> #{ret.inspect}")
+      ret
+    rescue Puppet::ExecutionFailure => e
+      debug("trusted?(#{home.inspect}, #{fingerprint.inspect}) failed: #{e.message.lines.first.to_s.strip}")
+      false
+    end
+
+    def set_ultimate_trust(home, fingerprint)
+      Tempfile.create(['metakey-ownertrust', '.txt']) do |f|
+        f.write("#{fingerprint}:6:\n")
+        f.flush
+        gpg_at(home, '--import-ownertrust', f.path)
+      end
+    end
+  end
+end

--- a/lib/puppet/provider/yumrepo_metadata_key/yum.rb
+++ b/lib/puppet/provider/yumrepo_metadata_key/yum.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative '../yumrepo_metadata_key'
+require_relative 'gpg_keyring'
 
-Puppet::Type.type(:yumrepo_metadata_key).provide(:yum, parent: Puppet::Provider::YumrepoMetadataKey) do
+Puppet::Type.type(:yumrepo_metadata_key).provide(:yum, parent: Puppet::Provider::YumrepoMetadataKey::GpgKeyring) do
   desc 'yum-3 per-repo gpgdir (EL7).'
 
   commands gpg: 'gpg', yum: 'yum'

--- a/lib/puppet/provider/yumrepo_metadata_key/yum.rb
+++ b/lib/puppet/provider/yumrepo_metadata_key/yum.rb
@@ -6,8 +6,8 @@ Puppet::Type.type(:yumrepo_metadata_key).provide(:yum, parent: Puppet::Provider:
   desc 'yum-3 per-repo gpgdir (EL7).'
 
   commands gpg: 'gpg', yum: 'yum'
-  confine    'os.family': 'RedHat'
-  defaultfor 'os.family': 'RedHat', 'os.release.major': '7'
+  confine    package_provider: 'yum'
+  defaultfor package_provider: 'yum'
 
   class << self
     def live_homes

--- a/lib/puppet/type/yumrepo_metadata_key.rb
+++ b/lib/puppet/type/yumrepo_metadata_key.rb
@@ -71,9 +71,9 @@ Puppet::Type.newtype(:yumrepo_metadata_key) do
     def insync?(is)
       return false if is.nil? || is == :absent
 
-      # Force updating of key if ownertrust isn't set correctly
-      unless provider.ultimate_trust?
-        debug('content insync? -> false (ownertrust is not ultimate)')
+      # Force re-import if the stored key isn't trusted.
+      unless provider.trusted?
+        debug('content insync? -> false (key not trusted)')
         return false
       end
 

--- a/lib/puppet/type/yumrepo_metadata_key.rb
+++ b/lib/puppet/type/yumrepo_metadata_key.rb
@@ -7,6 +7,9 @@ Puppet::Type.newtype(:yumrepo_metadata_key) do
     Manage a GPG key in a repository's metadata keystore (repo_gpgcheck=1).
     Title must be "<repo>:<fingerprint>", identified by the PRIMARY fingerprint.
 
+    On systems running `dnf` version `5`, `python3-libdnf5` must be installed before
+    this type can be used.
+
     @example Add a key for the `updates` repository
       yumrepo_metadata_key { 'updates:3B49DF2A0F5E6E4F7A1B2C3D4E5F60718293A4B5':
         ensure  => present,
@@ -96,4 +99,8 @@ Puppet::Type.newtype(:yumrepo_metadata_key) do
   end
 
   autorequire(:yumrepo) { [self[:repo]] }
+
+  # Order after the dnf5 python binding if the catalog installs it, so the dnf5
+  # provider can resolve keystore paths in the same run it is installed.
+  autorequire(:package) { ['python3-libdnf5'] }
 end

--- a/spec/acceptance/dnf_version_spec.rb
+++ b/spec/acceptance/dnf_version_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+describe 'dnf_version fact' do
+  it 'runs dnf --version' do
+    version = shell('dnf --version')
+    logger.info(version.stdout)
+    expect(version.stdout).not_to be_empty
+  end
+
+  it 'reports the installed major version' do
+    major = shell(%q(dnf --version | grep -oE '[0-9]+(\.[0-9]+)+' | head -1 | cut -d. -f1)).stdout.strip
+
+    pp = <<~PUPPET
+      $dnf_major_version = $facts['dnf_version']['major']
+      if $dnf_major_version == '#{major}' {
+        notify { "dnf_version.major=${facts['dnf_version']['major']}": }
+      } else {
+        fail("dnf_major_version ${dnf_major_version} didn't match expected version '#{major}'")
+      }
+    PUPPET
+
+    result = apply_manifest(pp, catch_failures: true)
+
+    expect(result.stdout).to match(%r{dnf_version\.major=#{major}\b})
+  end
+end

--- a/spec/acceptance/yumrepo_metadata_key_spec.rb
+++ b/spec/acceptance/yumrepo_metadata_key_spec.rb
@@ -55,7 +55,7 @@ describe 'yumrepo_metadata_key' do
           package: 'zip',
         },
       },
-      # Oracle Linux does not sign its base metadata, so test against a signed third-party repo (Docker CE) instead.
+      # Oracle Linux and Fedora do not sign their metadata, so test against a signed third-party repo (Docker CE) instead.
       'OracleLinux' => {
         '8' => {
           repo: 'docker',
@@ -67,6 +67,22 @@ describe 'yumrepo_metadata_key' do
         '9' => {
           repo: 'docker',
           baseurl: 'https://download.docker.com/linux/centos/9/x86_64/stable/',
+          key_url: 'https://download.docker.com/linux/centos/gpg',
+          fingerprint: '060A61C51B558A7F742B77AAC52FEB6B621E9F35',
+          package: 'docker-compose-plugin',
+        },
+      },
+      'Fedora' => {
+        '43' => {
+          repo: 'docker',
+          baseurl: 'https://download.docker.com/linux/fedora/43/x86_64/stable',
+          key_url: 'https://download.docker.com/linux/fedora/gpg',
+          fingerprint: '060A61C51B558A7F742B77AAC52FEB6B621E9F35',
+          package: 'docker-compose-plugin',
+        },
+        '44' => {
+          repo: 'docker',
+          baseurl: 'https://download.docker.com/linux/fedora/44/x86_64/stable',
           key_url: 'https://download.docker.com/linux/centos/gpg',
           fingerprint: '060A61C51B558A7F742B77AAC52FEB6B621E9F35',
           package: 'docker-compose-plugin',
@@ -99,6 +115,16 @@ describe 'yumrepo_metadata_key' do
         before => Package[#{repo[:package]}],
       }
 
+      # dnf5 needs the libdnf5 python binding for keystore path resolution; the
+      # type autorequires it. Install it before the purge takes away the stock
+      # repos it ships in.
+      if $facts['dnf_version']['major'] == '5' {
+        package { 'python3-libdnf5':
+          ensure => installed,
+          before => Resources['yumrepo'],
+        }
+      }
+
       # Some keyfiles bundle several keys; keep only the block we manage.
       $blocks = split(file('#{keyfile}'), /(?=-----BEGIN PGP PUBLIC KEY BLOCK-----)/).filter |$b| { $b =~ /BEGIN PGP/ }
 
@@ -125,7 +151,11 @@ describe 'yumrepo_metadata_key' do
     apply_manifest(pp, catch_failures: true)
     apply_manifest(pp, catch_changes: true)
 
-    keys = shell(%(for h in /var/cache/dnf/#{repo[:repo]}-*/pubring; do gpg --homedir "$h" --list-keys --with-colons; done)).stdout
+    keys = shell(<<~SH).stdout
+      shopt -s nullglob
+      for h in /var/cache/dnf/#{repo[:repo]}-*/pubring; do gpg --homedir "$h" --list-keys --with-colons; done
+      for f in /var/cache/libdnf5/#{repo[:repo]}-*/pubring/*.pub; do gpg --show-keys --with-colons "$f"; done
+    SH
     expect(keys).to match(repo[:fingerprint])
     expect(shell("rpm -q #{repo[:package]}", acceptable_exit_codes: [0, 1]).exit_code).to eq(0)
   end

--- a/spec/acceptance/yumrepo_metadata_key_spec.rb
+++ b/spec/acceptance/yumrepo_metadata_key_spec.rb
@@ -21,6 +21,13 @@ describe 'yumrepo_metadata_key' do
           fingerprint: '21CB256AE16FC54C6E652949702D426D350D275D',
           package: 'zip',
         },
+        '10' => {
+          repo: 'baseos',
+          baseurl: 'https://download.rockylinux.org/pub/rocky/10/BaseOS/x86_64/os/',
+          keyfile: '/etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-10',
+          fingerprint: 'FC226859C0860BF0DDB95B085B106C736FEDFC85',
+          package: 'zip',
+        },
       },
       'AlmaLinux' => {
         '8' => {

--- a/spec/unit/facter/dnf_version_spec.rb
+++ b/spec/unit/facter/dnf_version_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'dnf_version fact' do
+  def dnf_version(package_provider: 'dnf')
+    Facter.clear
+    Facter.add(:package_provider) { setcode { package_provider } }
+    load File.expand_path('../../../lib/facter/dnf_version.rb', __dir__)
+    Facter.value(:dnf_version)
+  end
+
+  after { Facter.clear }
+
+  it 'is unresolved off dnf systems' do
+    expect(dnf_version(package_provider: 'apt')).to be_nil
+  end
+
+  it 'is nil without dnf' do
+    allow(Facter::Util::Resolution).to receive(:which).with('dnf').and_return(nil)
+    expect(dnf_version).to be_nil
+  end
+
+  describe 'examples' do
+    [
+      {
+        os: 'Fedora 43',
+        command_output:
+          <<~EXAMPLE,
+            dnf5 version 5.2.18.0
+            dnf5 plugin API version 2.0
+            libdnf5 version 5.2.18.0
+            libdnf5 plugin API version 2.2
+
+            Loaded dnf5 plugins:
+              name: builddep
+              version: 1.0.0
+              API version: 2.0
+
+              name: changelog
+              version: 1.0.0
+              API version: 2.0
+
+              name: config-manager
+              version: 0.1.0
+              API version: 2.0
+
+              name: copr
+              version: 0.1.0
+              API version: 2.0
+
+              name: needs_restarting
+              version: 1.0.0
+              API version: 2.0
+
+              name: repoclosure
+              version: 1.0.0
+              API version: 2.0
+
+              name: repomanage
+              version: 1.0.0
+              API version: 2.0
+
+              name: reposync
+              version: 1.0.0
+              API version: 2.0
+          EXAMPLE
+        expected: { 'full' => '5.2.18.0', 'major' => '5' },
+      },
+      {
+        os: 'Fedora 44',
+        command_output:
+          <<~EXAMPLE,
+            dnf5 version 5.4.2.1
+            dnf5 plugin API version 2.0
+            libdnf5 version 5.4.2.1
+            libdnf5 plugin API version 2.2
+
+            Loaded dnf5 plugins:
+              name: builddep
+              version: 1.0.0
+              API version: 2.0
+
+              name: changelog
+              version: 1.0.0
+              API version: 2.0
+
+              name: config-manager
+              version: 0.1.0
+              API version: 2.0
+
+              name: copr
+              version: 0.1.0
+              API version: 2.0
+
+              name: needs_restarting
+              version: 1.0.0
+              API version: 2.0
+
+              name: repoclosure
+              version: 1.0.0
+              API version: 2.0
+
+              name: repomanage
+              version: 1.0.0
+              API version: 2.0
+
+              name: reposync
+              version: 1.0.0
+              API version: 2.0
+          EXAMPLE
+        expected: { 'full' => '5.4.2.1', 'major' => '5' },
+      },
+      {
+        os: 'Rocky 8',
+        command_output:
+          <<~EXAMPLE,
+            4.7.0
+              Installed: dnf-0:4.7.0-20.el8.noarch at Tue May 28 13:37:11 2024
+              Built    : infrastructure@rockylinux.org at Mon Oct 16 18:57:12 2023
+
+              Installed: rpm-0:4.14.3-31.el8.x86_64 at Tue May 28 13:37:09 2024
+              Built    : infrastructure@rockylinux.org at Wed Dec 13 16:45:41 2023
+          EXAMPLE
+        expected: { 'full' => '4.7.0', 'major' => '4' },
+      },
+      {
+        os: 'Rocky 9',
+        command_output:
+          <<~EXAMPLE,
+            4.14.0
+              Installed: dnf-0:4.14.0-34.el9_8.rocky.0.1.noarch at Mon May 25 20:18:55 2026
+              Built    : Rocky Linux Build System <releng@rockylinux.org> at Tue May 19 22:37:16 2026
+
+              Installed: rpm-0:4.16.1.3-40.el9.x86_64 at Mon May 25 20:18:53 2026
+              Built    : Rocky Linux Build System <releng@rockylinux.org> at Sun Dec 28 17:58:42 2025
+          EXAMPLE
+        expected: { 'full' => '4.14.0', 'major' => '4' },
+      },
+      {
+        os: 'Rocky 10',
+        command_output:
+          <<~EXAMPLE,
+            4.20.0
+              Installed: dnf-0:4.20.0-22.el10_2.rocky.0.1.noarch at Tue May 26 00:10:06 2026
+              Built    : Rocky Linux Build System <releng@rockylinux.org> at Tue May 19 14:06:23 2026
+
+              Installed: rpm-0:4.19.1.1-23.el10.x86_64 at Tue May 26 00:10:07 2026
+              Built    : Rocky Linux Build System <releng@rockylinux.org> at Sat Feb  7 14:50:19 2026
+          EXAMPLE
+        expected: { 'full' => '4.20.0', 'major' => '4' },
+      },
+    ].each do |example|
+      context "with #{example[:os]} example" do
+        it do
+          allow(Facter::Util::Resolution).to receive(:which).with('dnf').and_return('/usr/bin/dnf')
+          allow(Facter::Core::Execution).to receive(:execute).with('/usr/bin/dnf --version', on_fail: nil).and_return(example[:command_output])
+          expect(dnf_version).to eq(example[:expected])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
`dnf5` stores repo metadata keys completely differently to `dnf4` and `yum`. There's no GnuPG homedir, just one armored `<LONGKEYID>.pub` file per key.

Adds a `dnf_version` fact, confines the existing providers on it, extracts the GnuPG-homedir logic `dnf4` and `yum` share into a common parent, and then adds a `dnf5` provider on top.

No change to the supported OS list. The type works on Fedora 41+, but the rest of the module has unrelated `dnf5` breakage (`versionlock` and `post_transaction_action` need rewriting for new file formats).

Adding EL 10 to the metadata.json should be less work though. Since it's still based on `dnf` 4, much less needs fixing up.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>