### PR TITLE
Remove procs from `yumrepo_metadata_key` title patterns

### DIFF
--- a/lib/puppet/type/yumrepo_metadata_key.rb
+++ b/lib/puppet/type/yumrepo_metadata_key.rb
@@ -39,8 +39,8 @@ Puppet::Type.newtype(:yumrepo_metadata_key) do
       [
         %r{\A(.+):(\h{40})\z}i,
         [
-          [:repo, ->(x) { x }],
-          [:fingerprint, ->(x) { x.delete(' ').upcase }],
+          [:repo],
+          [:fingerprint],
         ],
       ],
     ]

--- a/spec/support/spec/shared_examples/generate_types.rb
+++ b/spec/support/spec/shared_examples/generate_types.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'puppet/generate/models/type/type'
+
+RSpec.shared_examples 'a type that works with `puppet generate types`' do
+  it 'does not raise an error' do
+    expect { Puppet::Generate::Models::Type::Type.new(described_class) }.not_to raise_error
+  end
+end

--- a/spec/unit/puppet/type/dnf_module_stream_spec.rb
+++ b/spec/unit/puppet/type/dnf_module_stream_spec.rb
@@ -2,17 +2,16 @@
 
 require 'spec_helper'
 
-dnf_module_stream = Puppet::Type.type(:dnf_module_stream)
-RSpec.describe 'the dnf_module_stream type' do
+describe Puppet::Type.type(:dnf_module_stream) do
   it 'loads' do
-    expect(dnf_module_stream).not_to be_nil
+    expect(described_class).not_to be_nil
   end
 
   it 'has parameter module' do
-    expect(dnf_module_stream.parameters).to include(:module)
+    expect(described_class.parameters).to include(:module)
   end
 
   it 'has property stream' do
-    expect(dnf_module_stream.properties.map(&:name)).to include(:stream)
+    expect(described_class.properties.map(&:name)).to include(:stream)
   end
 end

--- a/spec/unit/puppet/type/dnf_module_stream_spec.rb
+++ b/spec/unit/puppet/type/dnf_module_stream_spec.rb
@@ -7,6 +7,8 @@ describe Puppet::Type.type(:dnf_module_stream) do
     expect(described_class).not_to be_nil
   end
 
+  it_behaves_like 'a type that works with `puppet generate types`'
+
   it 'has parameter module' do
     expect(described_class.parameters).to include(:module)
   end

--- a/spec/unit/puppet/type/yumrepo_metadata_key_spec.rb
+++ b/spec/unit/puppet/type/yumrepo_metadata_key_spec.rb
@@ -14,6 +14,8 @@ describe Puppet::Type.type(:yumrepo_metadata_key) do
     expect(described_class).not_to be_nil
   end
 
+  it_behaves_like 'a type that works with `puppet generate types`'
+
   describe 'namevars' do
     it 'has 3 namevars' do
       expect(described_class.key_attributes.size).to eq(3)


### PR DESCRIPTION
`puppet generate types` rejects title patterns that use procs, so r10k deployments using `--generate-types` broke on 8.1.0.

The `upcase` is already done by the `fingerprint` parameter's `munge`, and the `delete(' ')` never did anything: the pattern matches 40 hex characters, so a fingerprint with spaces in it never got that far.

Fixes #390